### PR TITLE
Clarify that USB drive can be unplugged after export

### DIFF
--- a/docs/journalist/submissions.rst
+++ b/docs/journalist/submissions.rst
@@ -70,6 +70,10 @@ export to a Linux environment where these drives can be read. For assistance
 with this, see your SecureDrop administrator.
 
 Once you have provisioned a LUKS-encrypted export drive, insert the drive and
-click **Export**.
+click **Export**. You will be prompted for the password configured for this
+USB drive.
+
+After the export operation is complete, you can physically unplug the USB drive
+or export additional files.
 
 .. | screenshot_export_drive |


### PR DESCRIPTION
Small change, but wanted to make sure we capture this. We unlock/mount/unmount/lock for each file. Note that the client currently does not display a success message -- that's very important, and part of https://github.com/freedomofpress/securedrop-client/pull/666