### PR TITLE
Expand FAQ; updates and clarifications

### DIFF
--- a/docs/admin/known_issues.rst
+++ b/docs/admin/known_issues.rst
@@ -24,8 +24,9 @@ Current known issues
   performance and reliability of the updater.
 - Currently, only LUKS-encrypted *Export Devices* are supported. VeraCrypt support
   will be added in a future release.
-- Printer support is limited to specific models by Brother and HP. Support for
-  more non-networked printers will be added in a future release.
+- Printer support is limited to specific models by Brother and HP, and printing
+  different file types is not as reliable yet as under Tails. Support for
+  additional non-networked printers will be added in a future release.
 - "Flag for reply" functionality is not implemented in the *SecureDrop Client*.
   This is used when a source's reply key was not created on their first
   submission and needs to be created on their next visit.
@@ -34,3 +35,7 @@ Current known issues
   the *Journalist Interface* - see the `SecureDrop "Flag for Reply"
   documentation <https://docs.securedrop.org/en/stable/journalist.html#flag-for-reply>`_ for more information.
 - Currently, only app-based two-factor authentication (TOTP) is supported. 
+- The SecureDrop Client can only be configured with a single *Submission Key*.
+  If the *Submission Key* for your SecureDrop server was rotated in the past,
+  and submissions encrypted with the old key are still on your server, you will
+  not be able to open them with the SecureDrop Client.

--- a/docs/journalist/ending_session.rst
+++ b/docs/journalist/ending_session.rst
@@ -6,6 +6,6 @@ Ending your session
 When you are finished using SecureDrop Workstation, close the SecureDrop Client window and shut the computer down completely. This is to take advantage of the protections of full-disk encryption, and to avoid unauthorized access to the Workstation and the files and materials on it, which include any messages and submissions that you have downloaded.
 
 To shut down the computer, click your username in the top righthand corner of
-your screen, and select **Shut Down** from the context menu. Or, in the Qubes
-Applications menu, scroll to the bottom of the menu and select **Log Out > Shut
-Down**.
+your screen, and select **Shut Down** from the menu.
+
+.. | screenshot_shut_down |

--- a/docs/journalist/ending_session.rst
+++ b/docs/journalist/ending_session.rst
@@ -7,5 +7,3 @@ When you are finished using SecureDrop Workstation, close the SecureDrop Client 
 
 To shut down the computer, click your username in the top righthand corner of
 your screen, and select **Shut Down** from the menu.
-
-.. | screenshot_shut_down |

--- a/docs/journalist/faq.rst
+++ b/docs/journalist/faq.rst
@@ -121,15 +121,29 @@ to discuss with us, please open an issue `in our support portal`_ or send us a
 
 Why can’t I save or print from the Viewer VM apps?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+When you view a file on SecureDrop Workstation, it is opened in a disposable
+VM that cannot access the network or any peripherals. The VM and all its data
+will be destroyed the moment you close the viewer application.
 
-[This section is a stub]
- - Sandbox/isolation and comparison to SVS
- - Viewer VM being a "true" sandbox means avoiding opening potentially
-   malicious files in environments where you may also attach external devices
-   (printers, USB sticks); the workstation prevents this
+You can save files from a viewer application, but copies saved inside a disposable
+VM will be deleted when you close the application, and the changes will not be applied
+to the main copy of the file stored on your computer.
 
-It takes a long time to start SecureDrop Workstation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+You cannot print from the viewer application, because it does not have access
+to peripherals. This prevents malware from exfiltrating data (e.g., via attached
+USB devices), and from targeting hardware-level security vulnerabilities.
 
-[This section is a stub]
- - Updates must be fetched, they are important to security
+You *can* print files directly from the SecureDrop Client by clicking "Print"
+for a downloaded file, which will pass the file through to your USB printer
+without opening it in an interactive viewer application.
+
+Why does it take so long to start the SecureDrop Client?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+If the system has not been updated recently, the preflight updater will check
+for available security updates for all VMs used by SecureDrop Workstation,
+download, and apply them. This takes longer than for typical operating systems
+because of the number of VMs involved, and because some updates are performed
+over the Tor network.
+
+These updates are essential to keep SecureDrop Workstation secure. Their speed
+is expected to be improved in subsequent releases of SecureDrop Workstation.

--- a/docs/journalist/submissions.rst
+++ b/docs/journalist/submissions.rst
@@ -19,8 +19,10 @@ An animated spinner will indicate that the file is downloading:
 
 |screenshot_file_downloading|
 
-Once the file has downloaded, the filename will be visible, as will the words
-**Export** and **Print**.
+Once the file has been downloaded and decrypted, the filename will be visible,
+as will the action **Export** and **Print**. The displayed file size may increase
+after the download is complete, because the SecureDrop Client automatically
+decompresses the downloaded file.
 
 |screenshot_file_download_successful|
 
@@ -38,12 +40,6 @@ This disposable VM is a special isolated environment similar to the *Secure
 Viewing Station*; it does not have internet access, and isolates the files that
 you are viewing from other sensitive files and applications on the same
 computer.
-
-Because this isolation is important to the security of your system, you will
-notice that certain tools that you may be used to have been disabled. For
-example, the copy-and-paste keyboard will not allow you to copy to or from a
-disposable VM. For more information about this and other security features of
-Qubes, see `the Qubes OS documentation`_.
 
 .. tip:: In Qubes, window border colors are used to signify different virtual
    machines.


### PR DESCRIPTION
## Status

Ready for review

## Description

- Expand FAQ with missing entries

- Normal disposable VMs do allow copy and paste, so it's not quite
  right to describe this as a general security limitation of Qubes.
  We should explain our own copy and paste limitations separately.

- The "Log out" option was removed entirely due to its session-saving
  behavior.

- Note that we do not support more than one Submission Key