### PR TITLE
Use wget instead of missing curl

### DIFF
--- a/docs/admin/troubleshooting_connection.rst
+++ b/docs/admin/troubleshooting_connection.rst
@@ -142,7 +142,7 @@ You should see similar output as in ``sys-net`` before.
 
 Now, open a terminal in ``sd-whonix`` and run the following command:
 
-``curl -s https://check.torproject.org/ | cat | grep -m 1 "Congratulations"``
+``wget -qO- https://check.torproject.org/ | cat | grep -m 1 "Congratulations"``
 
 This command contacts a service intended for web browsers to verify whether your
 Tor connection is working.


### PR DESCRIPTION
Fixes #56 
## Test plan

Run this command in both `sd-proxy` and `sd-whonix` of a working SecureDrop Workstation install to confirm that it works for both VMs.