### PR TITLE
add instructions around sys-whonix tor connection

### DIFF
--- a/docs/admin/upgrading_to_fedora_31.rst
+++ b/docs/admin/upgrading_to_fedora_31.rst
@@ -73,7 +73,7 @@ Existing SecureDrop Workstation users may perform this process for ``work`` and
 ``vault`` only, as the other VMs will be updated by SecureDrop Workstation.
 
 Reboot the system to ensure the changes take effect. Alternatively, you can
-restart only the VMs you have updated.
+restart only the VMs you have updated. If you get a ``sys-whonix`` prompt asking how you want to connect to the Tor network, select the "Connect" option, which allows a direct connection to the Tor network.
 
 .. tip::
 


### PR DESCRIPTION
# Description

Add an instruction for selecting the "Connect" option to connect directly to the Tor network when sys-whonix prompts for this. 

A screenshot of the qubes dialog would be ideal, so if other agree, I can modify the sys-whonix qubes settings in order to get it to prompt me again and then take a screenshot.