### PR TITLE
Recommend reboot after first install

### DIFF
--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -427,7 +427,7 @@ Before setting up the set of VMs used by SecureDrop Workstation, you must config
 
     sdw-admin --apply
 
-This command will take a considerable amount of time and approximately 4GB of bandwidth, as it sets up multiple VMs and installs supporting packages. When it completes, your SecureDrop Workstation is finally ready to use!
+This command will take a considerable amount of time and approximately 4GB of bandwidth, as it sets up multiple VMs and installs supporting packages. When the command finishes, reboot the machine to complete the installation. Your SecureDrop Workstation is finally ready to use!
 
 Test the Workstation
 ~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Ensures that all AppVMs and TemplateVMs have been fully rebooted,
prior to first run. Related to QA findings in [0].

[0] https://github.com/freedomofpress/securedrop-workstation/issues/630