### PR TITLE
Documents use of test repos for qubes-mgmt-salt package

### DIFF
--- a/docs/admin/upgrading_to_fedora_31.rst
+++ b/docs/admin/upgrading_to_fedora_31.rst
@@ -40,25 +40,29 @@ bar.
 When the download has concluded, you will be prompted to install the package.
 Type ``y`` to proceed with the installation.
 
-TEMPORARY: Exclude Salt packages from updates
----------------------------------------------
+TEMPORARY: Update the ``qubes-mgmt-salt-vm-connector`` package
+--------------------------------------------------------------
 
-.. important:: Due to an `upstream issue <https://github.com/QubesOS/qubes-issues/issues/6188>`_,
-  you will need to exclude the ``salt`` and ``salt-ssh`` packages from updates, as the current
-  versions conflict with the Qubes updater. After the Fedora 31 template is installed, follow
-  the instructions below to do so:
+.. important:: Due to an `upstream issue <https://github.com/QubesOS/qubes-issues/issues/6188>`_, blocking updates
+  either via the Qubes Updater or the SecureDrop Workstation launcher, you will
+  need to temporarily update the ``qubes-mgmt-salt-vm-connector`` package in the ``fedora-31`` TemplateVM
+  with the version in the Qubes testing repo. Follow the steps below:
 
-* Open a ``fedora-31`` terminal via **Q > Template: fedora-31 > fedora-31: Terminal**.
-* Run the command ``echo "exclude=salt salt-ssh" | sudo tee -a /etc/dnf/dnf.conf``
-* Shut down the ``fedora-31`` VM  with the command ``sudo poweroff``.
+  * Open a ``fedora-31`` terminal via **Q > Template: fedora-31 > fedora-31: Terminal**.
+  * Run the command:
 
-These steps will be removed from this document as soon as the issue mentioned above
-is resolved, and future versions of SecureDrop Workstation will revert the configuration
-change above. If you wish to revert the workaround manually, follow these steps:
+  .. code-block:: sh
 
-* Open a ``fedora-31`` terminal via **Q > Template: fedora-31 > fedora-31: Terminal**.
-* Run the command ``sudo sed -i '/^exclude=/ d' /etc/dnf/dnf.conf``
-* Shut down the ``fedora-31`` VM with the command ``sudo poweroff``.
+    sudo dnf update --refresh --enablerepo=qubes-vm-r4.0-current-testing \
+      qubes-mgmt-salt-vm-connector
+
+  * Shut down the ``fedora-31`` VM  with the command ``sudo poweroff``.
+
+  These steps will be removed from this document as soon as the issue mentioned above
+  is resolved. This fix does not need to be reverted - as soon as the fixed version is
+  available in the prod repos, it will be applied with the next update.
+
+
 
 Update the Fedora-31 template
 -----------------------------


### PR DESCRIPTION
Includes the updated steps to pull in the test version of `qubes-mgmt-salt-vm-connector`,  as a more reasonable workaround for https://github.com/QubesOS/qubes-issues/issues/6188.

## Testing:
- [ ] CI is passing
- [ ] docs are clear and correct
- [ ] steps work on a Qubes system that does not already have downgraded and pinned versions of the `salt,salt-ssh` packages.