### PR TITLE
Remove v2 onion service docs; reinstate Fedora docs

### DIFF
--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -235,14 +235,6 @@ SecureDrop Workstation connects to your SecureDrop instance's API via the *Journ
       "cat /run/media/user/TailsData/Persistent/securedrop/install_files/ansible-base/app-journalist.auth_private" \
       > /tmp/journalist.txt
 
-  If your instance uses legacy v2 onion services, use the following command instead:
-
-  .. code-block:: sh
-
-    qvm-run --pass-io vault \
-      "cat /run/media/user/TailsData/Persistent/securedrop/install_files/ansible-base/app-journalist-aths" \
-      > /tmp/journalist.txt
-
 - Verify that the ``/tmp/journalist.txt`` file on ``dom0`` contains valid configuration information using the command ``cat /tmp/journalist.txt`` in the ``dom0`` terminal.
 
 - If you used an *Admin Workstation* USB drive, or you don't intend to copy a password database to this workstation, safely disconnect the USB drive now. In the ``vault`` file manager, select **+ Other Locations** and eject the TailsData volume, then disconnect the USB drive.
@@ -404,23 +396,17 @@ Before setting up the set of VMs used by SecureDrop Workstation, you must config
 
   - **submission_key_fpr**: use the value of the submission key fingerprint as displayed above
   - **hidserv.hostname**: use the hostname of the *Journalist Interface*, including the ``.onion`` TLD
-  - **hidserv.key**: use the value of the v2 HidServAuth token for the *Journalist Interface*, or the v3 private authorization key value if your SecureDrop instance uses v3 onion services
+  - **hidserv.key**: use the private v3 onion service authorization key value
   - **environment**: use the value ``prod``
 
 .. note::
-  You can find the values for the **hidserv.*** fields in the ``/tmp/journalist.txt`` file that you created in ``dom0`` earlier:
 
-  If your instance uses v2 onion services, the file will be formatted as follows:
+   You can find the values for the **hidserv.*** fields in the ``/tmp/journalist.txt`` file that you created in ``dom0`` earlier.
+   The file will be formatted as follows:
 
-  .. code-block:: none
+   .. code-block:: none
 
-    HidServAuth ONIONADDRESS.onion AUTHTOKEN # comments, can be ignored
-
-  If your instance uses v3 onion services, the file will be formatted as follows:
-
-  .. code-block:: none
-
-   ONIONADDRESS:descriptor:x25519:AUTHTOKEN
+     ONIONADDRESS:descriptor:x25519:AUTHTOKEN
 
 - Verify that the configuration is valid using the command below in the ``dom0`` terminal:
 

--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -15,6 +15,7 @@ Pre-install tasks:
 #. Download and verify Qubes OS
 #. Install Qubes OS
 #. Apply updates to system templates
+#. Install Fedora 33 base template
 
 Install tasks:
 ~~~~~~~~~~~~~~
@@ -167,6 +168,11 @@ Before installing SecureDrop Workstation, you must set up network and Tor access
   .. note:: If Tor connections are blocked on your network, you may need to configure Tor to use bridges in order to get a connection. For more information, see the `Anon Connection Wizard <https://www.whonix.org/wiki/Anon_Connection_Wizard>`_ documentation.
 
 - Once Tor has connected, select **Q > System Tools > Qubes Update** to update the system VMs. in the ``[Dom0] Qubes Updater`` window, first check ``Enable updates for qubes without known available updates``, then check all entries in the list above. Then, click **Next**. The system's VMs will be updated sequentially - this may take some time. When the updates are complete, click **Finish**.
+
+Install Fedora 33 template
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+See :doc:`upgrading_to_fedora_33`.
 
 Install tasks
 -------------

--- a/docs/admin/upgrading_to_fedora_33.rst
+++ b/docs/admin/upgrading_to_fedora_33.rst
@@ -1,0 +1,91 @@
+Upgrading to Fedora 33
+======================
+
+.. include:: ../includes/top-warning.rst
+
+.. note:: This advisory was written in June 2021, and will be removed when a new
+          version of Qubes that contains the Fedora 33 template is released.
+
+Why do I need to upgrade?
+-------------------------
+
+SecureDrop Workstation makes use of several Fedora-based VMs which are part of
+a Qubes installation by default, including ``sys-firewall``, ``sys-net``, ``sys-
+usb``, ``work``, and ``vault`` . In Qubes 4.0.4, these VMs are based on a
+Fedora 32 template.
+
+As of May 25, 2021, Fedora 32 templates are end-of-life. If you are
+provisioning SecureDrop Workstation for the first time, you will need to update
+your Fedora template manually to Fedora 33 *before* installing SecureDrop
+Workstation.
+
+If you are an existing SecureDrop Workstation user, SecureDrop Workstation
+will install the template automatically when updates are applied, but you
+should also :ref:`manually configure <configure_vms>` VMs not managed by
+SecureDrop Workstation to use the Fedora 33 template.
+
+Install Fedora-33 template
+--------------------------
+
+In a ``dom0`` terminal (**Qubes Application Menu > Terminal Emulator**), type
+the following to download the Fedora 33 template:
+
+.. code:: sh
+
+   sudo qubes-dom0-update qubes-template-fedora-33
+
+You will see some information from the package manager, including a progress
+bar.
+
+When the download has concluded, you will be prompted to install the package.
+Type ``y`` to proceed with the installation.
+
+
+Update the Fedora-33 template
+-----------------------------
+Once the template installation is complete, update the template using the Qubes
+Updater. Click **Q > System Tools > Qubes Update** in the application menu.
+Click the checkbox "Enable updates for qubes without known updates" option,
+and click the checkbox next to ``fedora-33``. Click **Next** and wait for
+any available updates to be downloaded and applied.
+
+.. _configure_vms:
+
+Configure VMs to use the new template
+-------------------------------------
+To apply the template to VMs that currently use an older version, open the
+Qube Manager via **Q > System Tools > Qube Manager**. All VMs will be visible at
+a glance; to change a VM's settings, right-click it and select **Qube Settings**.
+
+In the Qube Settings window, select ``fedora-33`` from the drop-down menu
+beside **Template**, then click **OK.**
+
+|screenshot_qsettings_fedora32|
+
+You should perform this process for:
+
+  - ``work``
+  - ``vault``
+  - ``sys-net``
+  - ``sys-usb``
+  - ``sys-firewall``.
+
+Existing SecureDrop Workstation users may perform this process for ``work`` and
+``vault`` only, as the other VMs will be updated by SecureDrop Workstation.
+
+Reboot the system to ensure the changes take effect. Alternatively, you can
+restart only the VMs you have updated. If you get a ``sys-whonix`` prompt asking how you want to connect to the Tor network, select the "Connect" option, which allows a direct connection to the Tor network.
+
+.. tip::
+
+   You can also use the **Qubes Template Manager** (also in **Q > System Tools**)
+   to make template changes. However, note that it will not allow you to make
+   template changes for VMs that are currently running, so you may have to
+   manually shut down VMs in the correct order to do so.
+
+.. |screenshot_qsettings_fedora32| image:: ../images/screenshot_qsettings_fedora32.png
+
+Getting Support
+---------------
+
+.. include:: ../includes/getting_support.rst

--- a/docs/admin/upgrading_to_fedora_33.rst
+++ b/docs/admin/upgrading_to_fedora_33.rst
@@ -12,12 +12,11 @@ Why do I need to upgrade?
 SecureDrop Workstation makes use of several Fedora-based VMs which are part of
 a Qubes installation by default, including ``sys-firewall``, ``sys-net``, ``sys-
 usb``, ``work``, and ``vault`` . In Qubes 4.0.4, these VMs are based on a
-Fedora 32 template.
+Fedora 32 template, which reached end-of-life on May 25, 2021.
 
-As of May 25, 2021, Fedora 32 templates are end-of-life. If you are
-provisioning SecureDrop Workstation for the first time, you will need to update
-your Fedora template manually to Fedora 33 *before* installing SecureDrop
-Workstation.
+If you are provisioning SecureDrop Workstation for the first time, you will need
+to update your Fedora template manually to Fedora 33 *before* installing
+SecureDrop Workstation.
 
 If you are an existing SecureDrop Workstation user, SecureDrop Workstation
 will install the template automatically when updates are applied, but you

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,6 +38,7 @@ against malware and other security risks. It is built on Qubes OS and requires a
    admin/troubleshooting_connection
    admin/provisioning_usb
    admin/known_issues
+   admin/upgrading_to_fedora_33
    admin/workstation_architecture
 
 


### PR DESCRIPTION
- Removes references to v2 onion services, which are no longer supported
- Reinstate docs for updating the Fedora base template. Qubes 4.0.4 [includes fedora-32](https://www.qubes-os.org/news/2021/03/04/qubes-4-0-4/), which has reached EOL, so we're back in a position where it makes sense to recommend updating the template before proceeding with the install.

(Note: The Fedora removal never made it into a `stable` build of the docs - you have to browse `latest` to (not) see it.) 

Fixes #80