### PR TITLE
Remove flag-for-reply references from admin and journalist guides

### DIFF
--- a/docs/admin/known_issues.rst
+++ b/docs/admin/known_issues.rst
@@ -27,13 +27,6 @@ Current known issues
 - Printer support is limited to specific models by Brother and HP, and printing
   different file types is not as reliable yet as under Tails. Support for
   additional non-networked printers will be added in a future release.
-- "Flag for reply" functionality is not implemented in the *SecureDrop Client*.
-  This is used when a source's reply key was not created on their first
-  submission and needs to be created on their next visit.
-  If you are logged into the SecureDrop Client, and the reply feature for a
-  source is disabled for more than a minute, they must be flagged for reply in
-  the *Journalist Interface* - see the `SecureDrop "Flag for Reply"
-  documentation <https://docs.securedrop.org/en/stable/journalist.html#flag-for-reply>`_ for more information.
 - Currently, only app-based two-factor authentication (TOTP) is supported. 
 - The SecureDrop Client can only be configured with a single *Submission Key*.
   If the *Submission Key* for your SecureDrop server was rotated in the past,

--- a/docs/journalist/sources.rst
+++ b/docs/journalist/sources.rst
@@ -48,19 +48,10 @@ client.
 Sources without reply keys
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 You may sometimes see the text "Awaiting encryption key from server" in a grayed
-out reply box for a source. This typically happens in the following situations:
-
-- A source has just contacted your SecureDrop moments ago, and the server has
-  not created an encryption key yet. If you are logged in, the key will be
-  automatically fetched as soon as it becomes available, usually within a few
-  seconds. At that point, the reply box will become available.
-
-- Your SecureDrop server is experiencing a surge of traffic, and the generation
-  of encryption keys has been temporarily disabled. You have to manually
-  `flag the source for reply`_, and the source has to log in again before you
-  can respond. This cannot currently be done from the SecureDrop Client.
-
-.. _`flag the source for reply`: https://docs.securedrop.org/en/stable/journalist.html#flag-for-reply
+out reply box for a source. This typically happens when a source has just 
+contacted your SecureDrop, and the server has not created an encryption key yet.
+If you are logged in, the key will be automatically fetched as soon as it 
+becomes available. At that point, the reply box will become available.
 
 Deleting a conversation
 -----------------------


### PR DESCRIPTION
Thanks to https://github.com/freedomofpress/securedrop/pull/5954 we can remove references to 'flag for reply' in the docs.

Feedback welcome on whether this explanation for the journalist workflow seems accurate, including in cases where there is a surge of traffic to the servers as a new source is submitting something.
