### PR TITLE
documents ThinkPad T14 compatibility

### DIFF
--- a/docs/admin/hardware.rst
+++ b/docs/admin/hardware.rst
@@ -17,12 +17,21 @@ More information on hardware compatibility can be found on the `Qubes OS System 
 
 In order to print submissions, a supported non-networked printer is required. We have tested and recommend the HP LaserJet Pro M404n. More printer options will be added in future releases.
 
-Lenovo T series Laptops
+.. _thinkpad_t_series:
+
+Lenovo T series laptops
 -----------------------
 
-Lenovo ThinkPad T490 (with 8th generation Intel Core processor)
+Lenovo ThinkPad T14 (with 10th-generation Intel Core processor)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The Thinkpad T490 **with an 8th generation Intel Core processor** is a recommended option for the SecureDrop Workstation. If you plan to use it, you should follow the instructions below to ensure that the BIOS is up to date and adequately configured before proceeding with the installation.
+The ThinkPad T14 **with a 10th-generation Intel Core processor** is a recommended option for the SecureDrop Workstation. If you plan to use it:
+
+- If your laptop has come with Ubuntu preinstalled, run its **Software Updater** to update the BIOS automatically (via ``fwupd``).
+- Otherwise, follow the instructions below to ensure that the BIOS is up to date.
+
+Lenovo ThinkPad T490 (with 8th-generation Intel Core processor)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The Thinkpad T490 **with an 8th-generation Intel Core processor** is a recommended option for the SecureDrop Workstation. If you plan to use it, you should follow the instructions below to ensure that the BIOS is up to date and adequately configured before proceeding with the installation.
 
 
 .. caution::

--- a/docs/admin/hardware.rst
+++ b/docs/admin/hardware.rst
@@ -26,7 +26,13 @@ Lenovo ThinkPad T14 (with 10th-generation Intel Core processor)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The ThinkPad T14 **with a 10th-generation Intel Core processor** is a recommended option for the SecureDrop Workstation. If you plan to use it:
 
-- If your laptop has come with Ubuntu preinstalled, run its **Software Updater** to update the BIOS automatically (via ``fwupd``).
+- If your laptop has come with Ubuntu preinstalled, run its **Software Updater** twice as follows:
+
+  #. to install software updates, especially for the ``fwupd`` package; and then
+  #. to run ``fwupd`` to update the BIOS automatically.
+
+  If **Software Updater** offers to run ``fwupd`` during step (1), decline until step (2), to make sure ``fwupd`` itself has received its latest security updates.
+
 - Otherwise, follow the instructions below to ensure that the BIOS is up to date.
 
 Network devices (Ethernet and Wi-Fi) will not immediately work out of the box and require a one-time manual configuration on install. After Qubes starts for the first time, when ``sys-net`` fails to start, follow the instructions below for the :ref:`thinkpad_t490`.

--- a/docs/admin/hardware.rst
+++ b/docs/admin/hardware.rst
@@ -87,17 +87,21 @@ Lenovo ThinkPad T480
 ~~~~~~~~~~~~~~~~~~~~
 The ThinkPad T480 is also a recommended option for SecureDrop Workstation, as it is being used by the core team for development and testing. If you plan to use it, you should follow the instructions below to ensure that the BIOS is up to date and adequately configured before proceeding with the installation:
 
-.. _t480_bios:
+.. _thinkpad_bios:
 
-Upgrading the BIOS (T480/T490)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Upgrading the BIOS on ThinkPad models T480, T490, and T14
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The instructions below assume the use of a Linux-based computer for the creation of a BIOS upgrade USB. To upgrade the BIOS:
 
-- Locate the machine type of the T480/T490 - it be found via the ``Main`` tab in Thinkpad Setup (accessed by pressing **Enter** on startup). For recent T480s, it will be a string like `20L5` or `20L6`.
+- Locate the ThinkPad's "machine type" in its BIOS setup program:
+
+  #. Boot (or reboot) the ThinkPad and follow the prompts to enter setup, usually via the <Enter> and <F1> keys.
+  #. On the **Main** tab, look for the **Machine Type Model**.  The first four characters, such as `20L5`, `20L6`, or `20S0`, are the machine type.
+
 - Visit `<https://support.lenovo.com>`_ in the Linux-based computer. Type the machine type found above into the search bar, then press **Enter**.
 - In the T480 Product Home page, select **Drivers And Software** and choose **BIOS/UEFI**.
-- Expand the **BIOS Update** listing and download the **BIOS Update (Bootable CD)** file.
+- Download the file called either **BIOS Update (Bootable CD)** or **BIOS Update (Utility & Bootable CD)**.
 
 .. note::
   A Tails USB can be used for the verification and conversion process described below, but the Lenovo support site blocks requests over Tor, preventing the ISO download. To work around this, either:
@@ -161,13 +165,15 @@ The instructions below assume the use of a Linux-based computer for the creation
 
   Once complete, remove the USB.
 
-- Plug the USB into the T480 and boot it, pressing **F12** on startup. Select the USB's listing in the boot menu.
+- Plug the USB into the ThinkPad.
+
+- Boot the ThinkPad and follow the prompts to enter its startup and boot menus, likely via the <Enter> and <F12> keys, respectively.
 
 - Follow the on-screen instructions to update the BIOS, including any mandatory reboots. Note that the instructions may refer to an update CD instead of your update USB.
 
 USB-C ports
 ~~~~~~~~~~~
-If you intend to use USB-C ports, please note that our recommended BIOS settings will disable dual USB-C/Thunderbolt ports (recognizable by the Thunderbolt logo next to the port). The T480 includes two USB-C ports, `specified <https://www.lenovo.com/us/en/laptops/thinkpad/thinkpad-t-series/ThinkPad-T480/p/22TP2TT4800>`__ as follows:
+If you intend to use USB-C ports, please note that our recommended BIOS settings will disable dual USB-C/Thunderbolt ports (recognizable by the Thunderbolt logo next to the port). The T480, for example, includes two USB-C ports, `specified <https://www.lenovo.com/us/en/laptops/thinkpad/thinkpad-t-series/ThinkPad-T480/p/22TP2TT4800>`__ as follows:
 
 - 1 x USB 3.1 Gen 1 Type-C (Power Delivery, DisplayPort, Data transfer)
 - 1 x USB 3.1 Gen 2 Type-C / Intel Thunderbolt 3 (Power Delivery, DisplayPort, Data transfer)

--- a/docs/admin/hardware.rst
+++ b/docs/admin/hardware.rst
@@ -35,7 +35,7 @@ The ThinkPad T14 **with a 10th-generation Intel Core processor** is a recommende
 
 - Otherwise, follow the instructions below to ensure that the BIOS is up to date.
 
-Network devices (Ethernet and Wi-Fi) will not immediately work out of the box and require a one-time manual configuration on install. After Qubes starts for the first time, when ``sys-net`` fails to start, follow the instructions below for the :ref:`thinkpad_t490`.
+The Ethernet controller will not immediately work out of the box and require a one-time manual configuration on install. After Qubes starts for the first time, when ``sys-net`` fails to start, follow the instructions below for the :ref:`thinkpad_t490`, but only for the ``dom0:00_1f.6`` Ethernet device.
 
 .. _thinkpad_t490:
 

--- a/docs/admin/hardware.rst
+++ b/docs/admin/hardware.rst
@@ -29,6 +29,10 @@ The ThinkPad T14 **with a 10th-generation Intel Core processor** is a recommende
 - If your laptop has come with Ubuntu preinstalled, run its **Software Updater** to update the BIOS automatically (via ``fwupd``).
 - Otherwise, follow the instructions below to ensure that the BIOS is up to date.
 
+Network devices (Ethernet and Wi-Fi) will not immediately work out of the box and require a one-time manual configuration on install. After Qubes starts for the first time, when ``sys-net`` fails to start, follow the instructions below for the :ref:`thinkpad_t490`.
+
+.. _thinkpad_t490:
+
 Lenovo ThinkPad T490 (with 8th-generation Intel Core processor)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The Thinkpad T490 **with an 8th-generation Intel Core processor** is a recommended option for the SecureDrop Workstation. If you plan to use it, you should follow the instructions below to ensure that the BIOS is up to date and adequately configured before proceeding with the installation.
@@ -69,7 +73,7 @@ For both device IDs (e.g. ``dom0:00_1f.6`` and ``dom0:00_14.3``), you will need 
   qvm-start sys-net
 
 
-``sys-net`` should now start, and network devices will be functional. This change is only required once on first install.
+``sys-net`` should now start, and network devices will be functional. This change is only required once on first install.  See the `Qubes documentation of this issue <https://www.qubes-os.org/doc/pci-troubleshooting/#unable-to-reset-pci-device-errors>`_ for more information.
 
 .. |screenshot_sys_net_pci_reset| image:: ../images/screenshot_sys_net_pci_reset.png
 

--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -67,7 +67,7 @@ To rotate passphrases for accounts, please see the `instructions <https://docs.s
 
 Apply BIOS updates and check settings
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Before beginning the Qubes installation, make sure that your Qubes-compatible computer's BIOS is updated to the latest available version. If you're using the recommended ThinkPad T480, see the :ref:`t480_bios` section in this documentation. The process will be different for other makes and models, and can usually be found on their respective support sites.
+Before beginning the Qubes installation, make sure that your Qubes-compatible computer's BIOS is updated to the latest available version. If you're using one of the recommended ThinkPad T-series models, see the section on :ref:`thinkpad_t_series`. The process will be different for other makes and models, and can usually be found on their respective support sites.
 
 Once the BIOS is up-to-date, boot into the BIOS setup utility and update its settings. Note that not all BIOS versions will support the items listed, but if available following changes are recommended:
 
@@ -79,6 +79,7 @@ Once the BIOS is up-to-date, boot into the BIOS setup utility and update its set
   - for Intel-based devices, **Intel VT-d** and **Intel VT-x** should be enabled
   - for AMD-based devices, **AMD-VI** and **AMD-V** should be enabled
 - Disable unnecessary I/O options such as Wireless WAN and  Bluetooth.
+- Disable unnecessary network options such as Wake-on-LAN and UEFI network stacks.
 - Disable Thunderbolt ports, or any other ports that allow Direct Memory Access (DMA).
 - Enable any physical tamper detection options.
 - Disable Computrace.

--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -306,9 +306,11 @@ With the key and configuration available in ``dom0``, you're ready to set up Sec
   .. code-block:: none
 
     securedrop-workstation-dom0-config-<versionNumber>-1.fc25.noarch.rpm:
-      Header V4 RSA/SHA256 Signature, key ID 7b22e6a3: OK
+      Header V4 RSA/SHA512 Signature, key ID 7b22e6a3: OK
+      Header SHA256 digest: OK
       Header SHA1 digest: OK
-      V4 RSA/SHA256 Signature, key ID 7b22e6a3: OK
+      Payload SHA256 digest: OK
+      V4 RSA/SHA512 Signature, key ID 7b22e6a3: OK
       MD5 digest: OK
 
 

--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -146,6 +146,11 @@ Install Fedora 34 template
 
 See :doc:`upgrading_fedora`.
 
+Install Whonix 16
+~~~~~~~~~~~~~~~~~
+
+Qubes 4.0.4 ships with Whonix 15, which reached end-of-life on November 14, 2021.  SecureDrop Workstation will install Whonix 16 for its own use.  However, if you see errors while updating the ``whonix-*-15`` templates, follow the `Whonix instructions for installing Whonix 16 <https://www.whonix.org/wiki/Qubes/Install#Installation>`_, then rerun the Qubes Updater as described above.
+
 Install tasks
 -------------
 

--- a/docs/admin/upgrading_fedora.rst
+++ b/docs/admin/upgrading_fedora.rst
@@ -64,7 +64,8 @@ You should perform this process for:
   - ``vault``
   - ``sys-net``
   - ``sys-usb``
-  - ``sys-firewall``.
+  - ``sys-firewall``
+  - ``default-mgmt-dvm``.
 
 Existing SecureDrop Workstation users may perform this process for ``work`` and
 ``vault`` only, as the other VMs will be updated by SecureDrop Workstation.


### PR DESCRIPTION
Closes freedomofpress/securedrop-workstation#749 by documenting:

1. hardware compatibility, BIOS updates, and Qubes settings for the ThinkPad T14; and
2. a few extra steps necessary as of January 2022 now that both Fedora 32 and Whonix 15 are obsolete on arrival in new Qubes 4.0.4 installations.