### PR TITLE
Add various headers that we want on all sites

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -28,5 +28,10 @@ http {
             rewrite ^/_/downloads/en/stable/pdf/$ /en/stable/SecureDropWorkstation.pdf permanent;
             rewrite ^/_/downloads/en/latest/pdf/$ /en/latest/SecureDropWorkstation.pdf permanent;
         }
+
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-XSS-Protection "1; mode=block" always;
+        add_header Referrer-Policy "same-origin" always;
     }
 }


### PR DESCRIPTION
Addresses: https://github.com/freedomofpress/infrastructure/issues/3735
Follow-up to: https://github.com/freedomofpress/securedrop-docs/pull/305

This adds the same headers as the `securedrop-docs` PR. Testing procedure is the same:

- Build and run container
- `curl -I http://127.0.0.1:5080/`
- Headers should be visible in the response
