### PR TITLE
Increased CI linkcheck timeout to 30min

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ jobs:
       - run:
           name: Run link checker
           command: make docs-linkcheck
+          no_output_timeout: 30m
 
 workflows:
   version: 2


### PR DESCRIPTION
Nightlies on this repo are failing more often than not, always about 2/3 of the way through the linkcheck command. 

This PR increases the no_output_timeout for this command from 10m to 30m. 
