### PR TITLE
document Qubes 4.1 compatibility with 2nd-gen ThinkPad T14

### DIFF
--- a/docs/admin/hardware.rst
+++ b/docs/admin/hardware.rst
@@ -49,9 +49,17 @@ Once ``sys-net`` starts, the Intel AX210 Wi-Fi controller will not automatically
 
 #. Connect the machine to the Internet via Ethernet.
 #. :doc:`Install and update the Fedora 36 template. <upgrading_fedora>`
-#. In the ``fedora-36`` template, run the command::
+#. In the ``sys-net`` VM, run the following command::
 
-      sudo mv /lib/firmware/iwlwifi-ty-a0-gf-a0.pnvm.xz ~
+      curl https://raw.githubusercontent.com/freedomofpress/securedrop-workstation-docs/main/docs/includes/iwlwifi/rc.local | sudo tee /rw/config/rc.local
+
+#. Then run the following command and verify the expected output::
+
+      cat /rw/config/rc.local
+
+   .. literalinclude:: ../includes/iwlwifi/rc.local
+      :linenos:
+      :emphasize-lines: 13-22
 
 #. Restart the machine.
 #. Once ``sys-net`` has come back up, the Network Manager should show available Wi-Fi networks.

--- a/docs/admin/hardware.rst
+++ b/docs/admin/hardware.rst
@@ -37,18 +37,18 @@ The 2nd-generation ThinkPad T14 **with an 11th-generation Intel Core processor**
 
 - Otherwise, follow the instructions below to ensure that the BIOS is up to date.
 
-The Ethernet and Wi-Fi controllers will not work without one-time manual configuration, as documented in the following sections.
+The Ethernet and Wi-Fi controllers may not work without one-time manual configuration, as documented in the following sections.
 
 Ethernet controller
 ^^^^^^^^^^^^^^^^^^^
 After Qubes starts for the first time, when ``sys-net`` fails to start, follow the instructions below for the :ref:`thinkpad_t490`, but only for the ``dom0:00_1f.6`` Ethernet device.
 
-Wi-Fi controller
-^^^^^^^^^^^^^^^^
-Once ``sys-net`` starts, the Intel AX210 Wi-Fi controller will not automatically be available to the Network Manager for you to select a network. [#ax210_dmesg]_  To fix this:
+Wi-Fi controller (AX210/211 only)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+If your T14 has an Intel AX210/211 Wi-Fi controller, it will not automatically be available to the Network Manager for you to select a network. [#ax210_dmesg]_  (If your T14 has an AX201 controller, it should work without any special configuration.)  To fix this:
 
+#. Open ``sys-net``'s **Qube Settings**.  On the **Advanced** tab, set **Kernel** to the highest-numbered entry beginning ``5.10``, which as of this writing is ``5.10.112-1.fc32``.
 #. Connect the machine to the Internet via Ethernet.
-#. :doc:`Install and update the Fedora 36 template. <upgrading_fedora>`
 #. In the ``sys-net`` VM, run the following command::
 
       curl https://raw.githubusercontent.com/freedomofpress/securedrop-workstation-docs/main/docs/includes/iwlwifi/rc.local | sudo tee /rw/config/rc.local

--- a/docs/admin/hardware.rst
+++ b/docs/admin/hardware.rst
@@ -47,8 +47,9 @@ Wi-Fi controller
 ^^^^^^^^^^^^^^^^
 Once ``sys-net`` starts, the Intel AX210 Wi-Fi controller will not automatically be available to the Network Manager for you to select a network. [#ax210_dmesg]_  To fix this:
 
-#. Use Ethernet to update the ``fedora-35`` template.  Wait for all updates to be installed.
-#. In the ``fedora-35`` template, run the command::
+#. Connect the machine to the Internet via Ethernet.
+#. :doc:`Install and update the Fedora 36 template. <upgrading_fedora>`
+#. In the ``fedora-36`` template, run the command::
 
       sudo mv /lib/firmware/iwlwifi-ty-a0-gf-a0.pnvm.xz ~
 

--- a/docs/admin/hardware.rst
+++ b/docs/admin/hardware.rst
@@ -24,9 +24,9 @@ In order to print submissions, a supported non-networked printer is required. We
 Lenovo T series laptops
 -----------------------
 
-Lenovo ThinkPad T14 (with 10th-generation Intel Core processor)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The ThinkPad T14 **with a 10th-generation Intel Core processor** is a recommended option for the SecureDrop Workstation. If you plan to use it:
+Lenovo ThinkPad T14 (2nd-generation)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The 2nd-generation ThinkPad T14 **with an 11th-generation Intel Core processor** is a recommended option for the SecureDrop Workstation beginning with Qubes 4.1. If you plan to use it:
 
 - If your laptop has come with Ubuntu preinstalled, run its **Software Updater** twice as follows:
 
@@ -37,7 +37,23 @@ The ThinkPad T14 **with a 10th-generation Intel Core processor** is a recommende
 
 - Otherwise, follow the instructions below to ensure that the BIOS is up to date.
 
-The Ethernet controller will not immediately work out of the box and require a one-time manual configuration on install. After Qubes starts for the first time, when ``sys-net`` fails to start, follow the instructions below for the :ref:`thinkpad_t490`, but only for the ``dom0:00_1f.6`` Ethernet device.
+The Ethernet and Wi-Fi controllers will not work without one-time manual configuration, as documented in the following sections.
+
+Ethernet controller
+^^^^^^^^^^^^^^^^^^^
+After Qubes starts for the first time, when ``sys-net`` fails to start, follow the instructions below for the :ref:`thinkpad_t490`, but only for the ``dom0:00_1f.6`` Ethernet device.
+
+Wi-Fi controller
+^^^^^^^^^^^^^^^^
+Once ``sys-net`` starts, the Intel AX210 Wi-Fi controller will not automatically be available to the Network Manager for you to select a network. [#ax210_dmesg]_  To fix this:
+
+#. Use Ethernet to update the ``fedora-35`` template.  Wait for all updates to be installed.
+#. In the ``fedora-35`` template, run the command::
+
+      sudo mv /lib/firmware/iwlwifi-ty-a0-gf-a0.pnvm.xz ~
+
+#. Restart the machine.
+#. Once ``sys-net`` has come back up, the Network Manager should show available Wi-Fi networks.
 
 .. _thinkpad_t490:
 
@@ -181,3 +197,12 @@ If you intend to use USB-C ports, please note that our recommended BIOS settings
 - 1 x USB 3.1 Gen 2 Type-C / Intel Thunderbolt 3 (Power Delivery, DisplayPort, Data transfer)
 
 The first of these ports will continue to function as a USB-C port. After disabling Thunderbolt, the second port can no longer be used for Thunderbolt or for USB-C data transfer, but it can still be used for power delivery (i.e. to plug in your AC adapter). If you are unsure about the features of your laptop's USB-C ports, or if you are using a different make or model, please consult the technical specifications of your laptop for further information.
+
+.. rubric:: Footnotes
+
+.. [#ax210_dmesg] In ``sys-net``'s ``dmesg`` output you'll see an error like:
+
+   .. code-block::
+
+      Timeout waiting for PNVM load!
+      Failed to start RT ucode: 110

--- a/docs/includes/iwlwifi/rc.local
+++ b/docs/includes/iwlwifi/rc.local
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# This script will be executed at every VM startup, you can place your own
+# custom commands here. This includes overriding some configuration in /etc,
+# starting services etc.
+
+# Example for overriding the whole CUPS configuration:
+#  rm -rf /etc/cups
+#  ln -s /rw/config/cups /etc/cups
+#  systemctl --no-block restart cups
+
+
+### BEGIN securedrop-workstation ###
+
+# Wait for iwlwifi to fail.  Then unload it, remove the incompatible firmware, and reload it.
+sleep 5
+modprobe -r iwlmvm iwlwifi
+rm -f /lib/firmware/iwlwifi-ty-a0-gf-a0.pnvm.xz
+modprobe iwlmvm
+modprobe iwlwifi
+
+### END securedrop-workstation ###


### PR DESCRIPTION
Updates ThinkPad T14 hardware recommendations to reflect the 2nd-generation model compatible with Qubes 4.1, including how to install an `/rw/config/rc.local` script in `sys-net` to enable the Intel AX210 Wi-Fi controller.


## Checklist

Please do review this pull request locally via `make docs` and confirm that:

- [ ] The instructions at `admin/hardware.html` are sensible.
- The script in `includes/iwlwifi/rc.local`:
    - [ ] looks good on visual review;
    - [ ] is available (`s/main/thinkpad-t14-gen2`) at <https://raw.githubusercontent.com/freedomofpress/securedrop-workstation-docs/thinkpad-t14-gen2/docs/includes/iwlwifi/rc.local>; and
    - [ ] is embedded correctly in `admin/hardware.html`.