### PR TITLE
Update documentation for Qubes 4.1

### DIFF
--- a/docs/admin/backup.rst
+++ b/docs/admin/backup.rst
@@ -3,22 +3,22 @@ Backup and Restore
 
 .. include:: ../includes/top-warning.rst
 
-QubesOS has a `backup utility <https://www.qubes-os.org/doc/backup-restore/>`_ 
-that allows for backup and restoration of user-specified VMs. 
+QubesOS has a `backup utility <https://www.qubes-os.org/doc/backup-restore/>`_
+that allows for backup and restoration of user-specified VMs.
 
 To perform backups, you will need:
 
  - a LUKS-encrypted external hard drive, with at least 50GB space
  - a secure place to store backup credentials (such as a password manager
-   on your primary laptop)    
+   on your primary laptop)
 
-Backup 
+Backup
 ------
 
 Preserve files from ``dom0``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Preserve key configuration files by coping them into the 
+Preserve key configuration files by coping them into the
 ``vault`` VM.
 
 In a ``dom0`` Terminal via **Q ▸ Terminal Emulator**:
@@ -31,12 +31,12 @@ In a ``dom0`` Terminal via **Q ▸ Terminal Emulator**:
 Open a ``vault`` Terminal and verify that the files were copied successfully:
 
   .. code-block:: sh
-  
+
     head -n1 ~/QubesIncoming/dom0/sd-journalist.sec # line contains "BEGIN PRIVATE KEY BLOCK"
     grep -q descriptor ~/QubesIncoming/dom0/config.json && echo OK # line is "OK"
 
 .. note::
-  If you have made advanced customizations to your Qubes Workstation, 
+  If you have made advanced customizations to your Qubes Workstation,
   you may need to back up additional components of ``dom0``. Refer to
   the `Qubes documentation <https://www.qubes-os.org/doc/backup-restore/>`_
   or contact Support.
@@ -47,10 +47,10 @@ Back up SecureDrop Workstation
 Ensure your storage medium is plugged in, attached to ``sd-devices``,
 and unlocked.
 
-Navigate to **Q ▸ System Tools ▸ Backup Qubes**, and move all VMs from 
-"Selected" to "Available" by pressing the ``<<`` button. 
+Navigate to **Q ▸ Qubes Tools ▸ Backup Qubes**, and move all VMs from
+"Selected" to "Available" by pressing the ``<<`` button.
 
-To target a VM for backup, highlight it and move it into the "Selected" 
+To target a VM for backup, highlight it and move it into the "Selected"
 column by pressing the ``>`` button. Select:
 
 - the ``vault`` VM
@@ -58,22 +58,22 @@ column by pressing the ``>`` button. Select:
 
 You do not need to back up the ``sd-`` VMs.
 
-Click "Next", and in "Backup destination," specify the VM and directory 
+Click "Next", and in "Backup destination," specify the VM and directory
 corresponding to your storage medium's current mount point.
 
-Set a strong, unique backup passphrase (7-word diceware), and ensure this 
-passphrase is stored securely outside SecureDrop Workstation. 
+Set a strong, unique backup passphrase (7-word diceware), and ensure this
+passphrase is stored securely outside SecureDrop Workstation.
 
-.. note:: 
- This passphrase protects sensitive 
+.. note::
+ This passphrase protects sensitive
  components of your SecureDrop instance, including the *Submission Private Key*.
- Ensure that it is a very strong password and is stored securely.   
+ Ensure that it is a very strong password and is stored securely.
 
 Uncheck "save backup profile," then proceed with the backup.
 
-QubesOS recommends verifying the integrity of the backup once the backup 
+QubesOS recommends verifying the integrity of the backup once the backup
 completes. This can be done by using the Restore Backup GUI tool and selecting
-"Verify backup integrity, but do not restore the data." For details, see the 
+"Verify backup integrity, but do not restore the data." For details, see the
 `QubesOS backup documentation <https://www.qubes-os.org/doc/backup-restore/>`_.
 
 Restore
@@ -82,20 +82,20 @@ Restore
 Reinstall QubesOS
 ~~~~~~~~~~~~~~~~~
 
-To restore SecureDrop Workstation, follow our 
+To restore SecureDrop Workstation, follow our
 :doc:`pre-install tasks <install>` to provision a QubesOS system complete with
-updated base templates. This time, during the installation wizard, un-check 
+updated base templates. This time, during the installation wizard, un-check
 ``create default application qubes (personal, work, untrusted, vault)``.
 
 Restore Backup
 ~~~~~~~~~~~~~~
 
 Plug in your backup medium and unlock it as during the backup. By default
-on a new system, your peripheral devices will be managed by a VM called 
-``sys-usb``. 
+on a new system, your peripheral devices will be managed by a VM called
+``sys-usb``.
 
-Navigate to **Q ▸ System Tools ▸ Restore Backup**, and enter the  
-location of the backup file. You do not need to adjust the default Restore 
+Navigate to **Q ▸ Qubes Tools ▸ Restore Backup**, and enter the  
+location of the backup file. You do not need to adjust the default Restore
 options, unless you have made customizations to the backup. Enter the
 decryption/verification passphrase, and proceed to restoring the available
 qubes (which should include the ``vault`` VM).
@@ -103,13 +103,13 @@ qubes (which should include the ``vault`` VM).
 Reinstall SecureDrop Workstation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Create a VM called ``work`` with default networking settings: 
+Create a VM called ``work`` with default networking settings:
 
   .. code-block:: sh
 
     qvm-create -l blue work
 
-Then, :ref:`download and verify <download_rpm>` the SecureDrop Workstation 
+Then, :ref:`download and verify <download_rpm>` the SecureDrop Workstation
 .rpm to the ``work`` VM and copy it to ``dom0``.
 
 Once you have a valid .rpm file in ``dom0``, install the .rpm by running:
@@ -126,8 +126,8 @@ VM:
     qvm-run --pass-io vault "cat QubesIncoming/dom0/sd-journalist.sec > /tmp/sd-journalist.sec"
     qvm-run --pass-io vault "cat QubesIncoming/dom0/config.json > /tmp/config.json"
 
-Optionally, inspect each file before proceeding. The first 
-file should be an ASCII-armored GPG private key file, and the second is a 
+Optionally, inspect each file before proceeding. The first
+file should be an ASCII-armored GPG private key file, and the second is a
 one-line file with the format ``ONIONADDRESS:descriptor:x25519:AUTHTOKEN``.
 
 Copy both files into place:
@@ -142,7 +142,7 @@ Verify that the configuration is valid:
 
     sdw-admin --validate
 
-If the above command does not produce any errors, the configuration is valid, 
+If the above command does not produce any errors, the configuration is valid,
 and you may remove the configuration files from the ``vault`` VM:
 
   .. code-block:: sh

--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -115,19 +115,23 @@ Follow the `installation documentation <https://www.qubes-os.org/doc/installatio
 - Use all available storage space for the installation (as the computer should be dedicated to SecureDrop Workstation).
 - Set a strong FDE passphrase - a 6-word Diceware passphrase is recommended.
 - Create an administrative account named ``user`` with a strong password.
-- In the template configuration, ensure that the following options are checked:
 
-  - "Create default system qubes (sys-net, sys-firewall, default DispVM)"
-  - "Make sys-firewall and sys-usb disposable"
-- If there is a grayed out option "USB qube configuration disabled", make a note of this. An additional setup step will be required (see below).
-
-  .. note:: Qubes is not intended to have multiple user accounts, so your account name and password will be shared by all SecureDrop Workstation users. The password will be required to log in and unlock the screen during sessions - choosing something strong but memorable and easily typed is recommended!
+.. note:: Qubes is not intended to have multiple user accounts, so your account name and password will be shared by all SecureDrop Workstation users. The password will be required to log in and unlock the screen during sessions - choosing something strong but memorable and easily typed is recommended!
 
 Once the installation is complete, you will be prompted to reboot into Qubes. Reboot, removing the install USB when the computer restarts.
 
 You will be prompted to enter the FDE passphrase set during installation.
 
-After the disk is unlocked and Qubes starts, you will be prompted to complete the initial setup. Click the Qubes OS icon, then accept the default options and click **Done**. Finally, click **Finish Configuration** to set up the default system TemplateVMs and AppVMs.
+After the disk is unlocked and Qubes starts, you will be prompted to complete the initial setup. Click the Qubes OS icon.
+
+On the configuration screen, ensure that the following options are checked:
+
+ - "Create default system qubes (sys-net, sys-firewall, default DispVM)"
+ - "Make sys-firewall and sys-usb disposable"
+
+If there is a grayed out option "USB qube configuration disabled", make a note of this. An additional setup step will be required (see below).
+
+Finally, click **Finish Configuration** to set up the default system TemplateVMs and AppVMs.
 
 Once the initial setup is complete, the login dialog will be displayed. Log in using the username and password set during installation.
 
@@ -141,7 +145,11 @@ After the command exits, confirm that you see an entry "Service: sys-usb" in the
 
 Apply ``dom0`` updates (estimated wait time: 15-30 minutes)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-``dom0`` is the most trusted domain on Qubes OS, and has privileged access to all other VMs. As such, it is important to ensure that all available security updates have been applied to ``dom0`` before proceeding. Open a ``dom0`` terminal via the Qubes menu (the **Q** icon in the upper left corner): **Q > Terminal Emulator**. Run the following command:
+``dom0`` is the most trusted domain on Qubes OS, and has privileged access to all other VMs. As such, it is important to ensure that all available security updates have been applied to ``dom0`` as the first step after the installation.
+
+After logging in, use the network manager widget in the upper-right panel to configure your network connection.
+
+Open a ``dom0`` terminal via the Qubes menu (the **Q** icon in the upper left corner): **Q > Terminal Emulator**. Run the following command:
 
 .. code-block:: sh
 
@@ -153,10 +161,7 @@ After updating ``dom0``, reboot the workstation to ensure that all updates have 
 
 Apply updates to system templates (estimated wait time: 45-60 minutes)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Before installing SecureDrop Workstation, you must set up network and Tor access, then update the system VMs:
-
-- After logging in, use the network manager widget in the upper-right panel to configure your network connection.
+After logging in again, confirm that the network manager successfully connects you to the configured network. If necessary, verify the network settings using the network manager widget.
 
 - Next, configure Tor by selecting the Qubes menu (the **Q** icon in the upper left corner) and selecting **Service: sys-whonix > sys-whonix: Anon Connection Wizard**. In most cases, choosing the default **Connect** option is best. Click **Next**, then **Next** again. Then, if Tor connects successfully, click **Finish**. If Tor fails to connect, make sure your network conection is up and does not filter Tor connections, then try again.
 

--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -424,6 +424,8 @@ Before setting up the set of VMs used by SecureDrop Workstation, you must config
 
     sdw-admin --validate
 
+- Configure infinite scrollback for your terminal via **Edit > Preferences > General > Unlimited scrollback**. This helps to ensure that you will be able to review any error output printed to the terminal during the installation.
+
 - Finally, in the ``dom0`` terminal, run the command:
 
   .. code-block:: sh

--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -89,7 +89,7 @@ If the Qubes hardware compatibility list entry for your computer recommends the 
 
 Download and verify Qubes OS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-On the working computer, download the Qubes OS ISO for version ``4.1`` from `https://www.qubes-os.org/downloads/ <https://www.qubes-os.org/downloads/#qubes-release-4-1-0>`_. The ISO is 5.6 GiB approximately, and may take some time to download based on the speed of your Internet connection.
+On the working computer, download the Qubes OS ISO for version ``4.1.0`` from `https://www.qubes-os.org/downloads/ <https://www.qubes-os.org/downloads/#qubes-release-4-1-0>`_. The ISO is 5.6 GiB approximately, and may take some time to download based on the speed of your Internet connection.
 
 Follow the linked instructions to `verify the ISO <https://www.qubes-os.org/security/verifying-signatures/#how-to-verify-detached-pgp-signatures-on-qubes-isos>`_.
 

--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -141,7 +141,15 @@ If, during the installation, you encountered the grayed out option "USB qube con
 
   sudo qubesctl state.sls qvm.sys-usb
 
-After the command exits, confirm that you see an entry "Service: sys-usb" in the Qubes menu.
+After the command exits, confirm that you see an entry "Service: sys-usb" in the Qubes menu. If ``sys-usb`` is not running, you can start it with the command ``qvm-start sys-usb`` in ``dom0``. Once ``sys-usb`` is running, click the devices widget in the upper right panel to expand a listing of all devices detected by Qubes OS.
+
+Now, insert a safe USB device you intend to use with the SecureDrop Workstation. Click the devices widget again. Does the newly attached USB device appear in the list? If so, USB support is working and you can proceed with the installation. If you do encounter the error message "Denied qubes.InputKeyboard from sys-usb to dom0", you need to additionally enable USB keyboard support:
+
+.. code-block:: sh
+
+  sudo qubesctl state.sls qvm.usb-keyboard
+
+Please note that we recommend against the use of a USB keyboard for security reasons, but this error can also occur in combination with other USB devices on some hardware.
 
 Apply ``dom0`` updates (estimated wait time: 15-30 minutes)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -321,7 +329,7 @@ With the key and configuration available in ``dom0``, you're ready to set up Sec
 
     dnf download securedrop-workstation-dom0-config
 
-  Note the release version number in the filename, you'll need it below.
+  Note the release version number in the filename, you'll need it below. During the download, you may be prompted to confirm importing the Qubes OS Release 4 Signing Key. You can safely do so; it will not be used during the subsequent steps.
 
 - Verify the package with the following command:
 

--- a/docs/admin/upgrading_fedora.rst
+++ b/docs/admin/upgrading_fedora.rst
@@ -8,7 +8,7 @@ Why do I need to upgrade?
 
 SecureDrop Workstation makes use of several Fedora-based VMs which are part of
 a Qubes installation by default, including ``sys-firewall``, ``sys-net``, ``sys-
-usb``, ``work``, and ``vault`` . In Qubes 4.1, these VMs are based on a
+usb``, ``work``, and ``vault`` . In Qubes 4.1.0, these VMs are based on a
 Fedora 34 template, which reached end-of-life on June 7, 2022.
 
 If you are provisioning SecureDrop Workstation for the first time, you will need

--- a/docs/admin/upgrading_fedora.rst
+++ b/docs/admin/upgrading_fedora.rst
@@ -63,12 +63,20 @@ You should perform this process for:
   - ``work``
   - ``vault``
   - ``sys-net``
-  - ``sys-usb``
-  - ``sys-firewall``
   - ``default-mgmt-dvm``.
 
-Existing SecureDrop Workstation users may perform this process for ``work`` and
-``vault`` only, as the other VMs will be updated by SecureDrop Workstation.
+Create a new disposable VM template based on Fedora 36 by running
+the following commands in ``dom0``:
+
+.. code:: sh
+
+  qvm-create -l red -t fedora-36 fedora-36-dvm
+  qvm-prefs fedora-36-dvm template_for_dispvms True
+  qvm-features fedora-36-dvm appmenus-dispvm 1
+  qubes-prefs default-dispvm fedora-36-dvm
+
+Now, switch the templates for ``sys-usb`` and ``sys-firewall`` to
+``fedora-36-dvm`` using the same process that you used above.
 
 Reboot the system to ensure the changes take effect. Alternatively, you can
 restart only the VMs you have updated. If you get a ``sys-whonix`` prompt asking how you want to connect to the Tor network, select the "Connect" option, which allows a direct connection to the Tor network.

--- a/docs/admin/upgrading_fedora.rst
+++ b/docs/admin/upgrading_fedora.rst
@@ -1,4 +1,4 @@
-Upgrading to Fedora 35
+Upgrading to Fedora 36
 ======================
 
 .. include:: ../includes/top-warning.rst
@@ -8,41 +8,41 @@ Why do I need to upgrade?
 
 SecureDrop Workstation makes use of several Fedora-based VMs which are part of
 a Qubes installation by default, including ``sys-firewall``, ``sys-net``, ``sys-
-usb``, ``work``, and ``vault`` . In Qubes 4.0.4, these VMs are based on a
-Fedora 32 template, which reached end-of-life on May 25, 2021.
+usb``, ``work``, and ``vault`` . In Qubes 4.1, these VMs are based on a
+Fedora 34 template, which reached end-of-life on June 7, 2022.
 
 If you are provisioning SecureDrop Workstation for the first time, you will need
-to update your Fedora template manually to Fedora 35 *before* installing
+to update your Fedora template manually to Fedora 36 *before* installing
 SecureDrop Workstation.
 
 If you are an existing SecureDrop Workstation user, SecureDrop Workstation
 will install the template automatically when updates are applied, but you
 should also :ref:`manually configure <configure_vms>` VMs not managed by
-SecureDrop Workstation to use the Fedora 35 template.
+SecureDrop Workstation to use the Fedora 36 template.
 
-Install Fedora-34 template
+Install Fedora-36 template
 --------------------------
 
 In a ``dom0`` terminal (**Qubes Application Menu > Terminal Emulator**), type
-the following to download the Fedora 35 template:
+the following to download the Fedora 36 template:
 
 .. code:: sh
 
-   sudo qubes-dom0-update qubes-template-fedora-35
+   sudo qvm-template install fedora-36
 
-You will see some information from the package manager, including a progress
+You will see some information from the template manager, including a progress
 bar.
 
 When the download has concluded, you will be prompted to install the package.
 Type ``y`` to proceed with the installation.
 
 
-Update the Fedora-34 template
+Update the Fedora-36 template
 -----------------------------
 Once the template installation is complete, update the template using the Qubes
-Updater. Click **Q > System Tools > Qubes Update** in the application menu.
+Updater. Click **Q > Qubes Tools > Qubes Update** in the application menu.
 Click the checkbox "Enable updates for qubes without known updates" option,
-and click the checkbox next to ``fedora-35``. Click **Next** and wait for
+and click the checkbox next to ``fedora-36``. Click **Next** and wait for
 any available updates to be downloaded and applied.
 
 .. _configure_vms:
@@ -50,10 +50,10 @@ any available updates to be downloaded and applied.
 Configure VMs to use the new template
 -------------------------------------
 To apply the template to VMs that currently use an older version, open the
-Qube Manager via **Q > System Tools > Qube Manager**. All VMs will be visible at
+Qube Manager via **Q > Qubes Tools > Qube Manager**. All VMs will be visible at
 a glance; to change a VM's settings, right-click it and select **Qube Settings**.
 
-In the Qube Settings window, select ``fedora-35`` from the drop-down menu
+In the Qube Settings window, select ``fedora-36`` from the drop-down menu
 beside **Template**, then click **OK.**
 
 |screenshot_qsettings_fedora32|
@@ -75,7 +75,7 @@ restart only the VMs you have updated. If you get a ``sys-whonix`` prompt asking
 
 .. tip::
 
-   You can also use the **Qubes Template Manager** (also in **Q > System Tools**)
+   You can also use the **Qubes Template Manager** (also in **Q > Qubes Tools**)
    to make template changes. However, note that it will not allow you to make
    template changes for VMs that are currently running, so you may have to
    manually shut down VMs in the correct order to do so.


### PR DESCRIPTION
This does not include hardware-specific documentation updates or screenshot updates.

Partially resolves #104 (except for hardware-specific updates)
Resolves #108
Resolves #110 
Resolves #111

## Status 

Ready for review

## Test plan

- Review visually for inconsistencies, errors, or parts of https://workstation.securedrop.org/ that haven't been updated yet but should be.
- Ideally, at least one person should try to perform a prod install following the revised docs.