### PR TITLE
Clarifications to installation and restore docs

### DIFF
--- a/docs/admin/backup.rst
+++ b/docs/admin/backup.rst
@@ -3,7 +3,7 @@ Backup and Restore
 
 .. include:: ../includes/top-warning.rst
 
-QubesOS has a `backup utility <https://www.qubes-os.org/doc/backup-restore/>`_
+Qubes OS has a `backup utility <https://www.qubes-os.org/doc/backup-restore/>`_
 that allows for backup and restoration of user-specified VMs.
 
 To perform backups, you will need:
@@ -71,25 +71,34 @@ passphrase is stored securely outside SecureDrop Workstation.
 
 Uncheck "save backup profile," then proceed with the backup.
 
-QubesOS recommends verifying the integrity of the backup once the backup
+Qubes OS recommends verifying the integrity of the backup once the backup
 completes. This can be done by using the Restore Backup GUI tool and selecting
 "Verify backup integrity, but do not restore the data." For details, see the
-`QubesOS backup documentation <https://www.qubes-os.org/doc/backup-restore/>`_.
+`Qubes OS backup documentation <https://www.qubes-os.org/doc/backup-restore/>`_.
 
 Restore
 -------
 
-Reinstall QubesOS
-~~~~~~~~~~~~~~~~~
+Reinstall Qubes OS
+~~~~~~~~~~~~~~~~~~
 
 To restore SecureDrop Workstation, follow our
-:doc:`pre-install tasks <install>` to provision a QubesOS system complete with
-updated base templates. This time, during the installation wizard, un-check
-``create default application qubes (personal, work, untrusted, vault)``.
+:doc:`pre-install tasks <install>` to provision a Qubes OS system complete with
+updated base templates.
+
+Rename or delete redundant AppVMs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+By default, Qubes OS will create the AppVMs ``personal``, ``work``, ``untrusted``
+and ``vault`` as part of the installation process. Rename or delete any
+of these newly created AppVMs whose names conflict with the AppVMs you
+intend to restore from a backup.
+
+Example: If you restore only ``vault``, rename or delete the existing
+``vault`` VM prior to restoring the backup. You can do so in
+**Q > Domain: vault > vault: Qube Settings** (the VM must not be running).
 
 Restore Backup
 ~~~~~~~~~~~~~~
-
 Plug in your backup medium and unlock it as during the backup. By default
 on a new system, your peripheral devices will be managed by a VM called
 ``sys-usb``.
@@ -103,7 +112,7 @@ qubes (which should include the ``vault`` VM).
 Reinstall SecureDrop Workstation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Create a VM called ``work`` with default networking settings:
+If you do not already have a ``work`` VM, create it with default networking settings:
 
   .. code-block:: sh
 
@@ -127,8 +136,10 @@ VM:
     qvm-run --pass-io vault "cat QubesIncoming/dom0/config.json" > /tmp/config.json
 
 Optionally, inspect each file before proceeding. The first
-file should be an ASCII-armored GPG private key file, and the second is a
-one-line file with the format ``ONIONADDRESS:descriptor:x25519:AUTHTOKEN``.
+file should be an ASCII-armored GPG private key file. The second file should
+follow the format of the `example configuration file <https://raw.githubusercontent.com/freedomofpress/securedrop-workstation/main/config.json.example>`_,
+with values for its fields (e.g., ``hostname``, ``submission_key_fpr``) specific to
+your configuration. The file may be formatted in a single line without whitespace.
 
 Copy both files into place:
 

--- a/docs/admin/hardware.rst
+++ b/docs/admin/hardware.rst
@@ -13,6 +13,8 @@ In order to install and use SecureDrop Workstation, you will need a Qubes-Compat
 - a minimum of 16GB RAM (32GB recommended for production use)
 - sufficient disk space for the Qubes OS base install and SecureDrop Workstation VMs (a 128GB or greater SSD is recommended)
 
+We recommend against a device that requires an external USB keyboard for security reasons.
+
 More information on hardware compatibility can be found on the `Qubes OS System Requirements <https://www.qubes-os.org/doc/system-requirements/>`_ page, and information on specific systems can be found via the `hardware compatibility list <https://www.qubes-os.org/hcl/>`_.
 
 In order to print submissions, a supported non-networked printer is required. We have tested and recommend the HP LaserJet Pro M404n. More printer options will be added in future releases.

--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -14,6 +14,7 @@ Pre-install tasks:
 #. Apply BIOS updates and check settings
 #. Download and verify Qubes OS
 #. Install Qubes OS
+#. (Hardware-dependent) Apply USB fixes
 #. Apply updates to system templates
 
 Install tasks:
@@ -128,13 +129,18 @@ On the configuration screen, ensure that the following options are checked:
  - "Create default system qubes (sys-net, sys-firewall, default DispVM)"
  - "Make sys-firewall and sys-usb disposable"
 
-If there is a grayed out option "USB qube configuration disabled", make a note of this. An additional setup step will be required (see below).
+If there is a grayed out option "USB qube configuration disabled", make a note of this. An additional setup step will be required (see next section).
 
 Finally, click **Finish Configuration** to set up the default system TemplateVMs and AppVMs.
 
 Once the initial setup is complete, the login dialog will be displayed. Log in using the username and password set during installation.
 
-If, during the installation, you encountered the grayed out option "USB qube configuration disabled", you must now create a VM to access your USB devices. To do so, open a ``dom0`` terminal via the Qubes menu (the **Q** icon in the upper left corner): **Q > Terminal Emulator**. Run the following command:
+(Hardware-dependent) Apply USB fixes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If, during the installation, you encountered the grayed out option "USB qube configuration disabled", you must now create a VM to access your USB devices. If you did not encounter this issue, you can skip this section.
+
+To create a USB qube, open a ``dom0`` terminal via the Qubes menu (the **Q** icon in the upper left corner): **Q > Terminal Emulator**. Run the following command:
 
 .. code-block:: sh
 
@@ -148,7 +154,7 @@ Now, insert a safe USB device you intend to use with the SecureDrop Workstation.
 
   sudo qubesctl state.sls qvm.usb-keyboard
 
-Please note that we recommend against the use of a USB keyboard for security reasons, but this error can also occur in combination with other USB devices on some hardware.
+While we recommend against the use of a USB keyboard for security reasons, this error can also occur in combination with other USB devices on some hardware.
 
 Apply ``dom0`` updates (estimated wait time: 15-30 minutes)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
- Sets `sys-usb` clarifications apart into their own section to mitigate confusion
- Updates description of `config.json` file to match its expected contents
- Replaces the recommendation to skip creating default VMs with a step to rename/delete VMs with conflicting names
- Adds the recommendation to avoid using a USB keyboard (if at all possible) to the hardware section
- Updates to `Qubes OS` name to be consistent

## Status

Ready for review