### PR TITLE
Set linkcheck timeout; update Lenovo link

### DIFF
--- a/docs/admin/hardware.rst
+++ b/docs/admin/hardware.rst
@@ -200,7 +200,7 @@ The instructions below assume the use of a Linux-based computer for the creation
 
 USB-C ports
 ~~~~~~~~~~~
-If you intend to use USB-C ports, please note that our recommended BIOS settings will disable dual USB-C/Thunderbolt ports (recognizable by the Thunderbolt logo next to the port). The T480, for example, includes two USB-C ports, `specified <https://www.lenovo.com/us/en/laptops/thinkpad/thinkpad-t-series/ThinkPad-T480/p/22TP2TT4800>`__ as follows:
+If you intend to use USB-C ports, please note that our recommended BIOS settings will disable dual USB-C/Thunderbolt ports (recognizable by the Thunderbolt logo next to the port). The T480, for example, includes two USB-C ports, `specified <https://psref.lenovo.com/syspool/Sys/PDF/ThinkPad/ThinkPad_T480/ThinkPad_T480_Spec.PDF>`__ as follows:
 
 - 1 x USB 3.1 Gen 1 Type-C (Power Delivery, DisplayPort, Data transfer)
 - 1 x USB 3.1 Gen 2 Type-C / Intel Thunderbolt 3 (Power Delivery, DisplayPort, Data transfer)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -233,3 +233,7 @@ epub_copyright = copyright
 
 # A list of files that should not be packed into the epub file.
 epub_exclude_files = ['search.html']
+
+# The default is to use Python’s global socket timeout, which may be `None`.
+# This can cause CI jobs to time out.
+linkcheck_timeout = 30


### PR DESCRIPTION
The Lenovo URL was timing out in CI (but not locally). This PR enforces a hard timeout on all linkchecks, and also updates the URL to a better location (the old URL no longer contains the actual specs).

Supersedes #103, which was reverted in #120

## Status

Ready for review. 

Note: `docs-linkcheck` only runs as a nightly job; I've tested the behavior by temporarily dropping the schedule trigger while working on this PR.  You can see a successful run here: https://app.circleci.com/pipelines/github/freedomofpress/securedrop-workstation-docs/699/workflows/a32bacc0-9939-4b69-be3b-fe28e9835274/jobs/686