### PR TITLE
Update Qubes version in install instructions to 4.1.2

### DIFF
--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -89,7 +89,7 @@ If the Qubes hardware compatibility list entry for your computer recommends the 
 
 Download and verify Qubes OS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-On the working computer, download the Qubes OS ISO for version ``4.1.1`` from `https://www.qubes-os.org/downloads/ <https://www.qubes-os.org/downloads/#qubes-release-4-1-1>`_. The ISO is 5.4 GiB approximately, and may take some time to download based on the speed of your Internet connection.
+On the working computer, download the Qubes OS ISO for version ``4.1.2`` from `https://www.qubes-os.org/downloads/ <https://www.qubes-os.org/downloads/#qubes-release-4-1-2>`_. The ISO is 5.4 GiB approximately, and may take some time to download based on the speed of your Internet connection.
 
 Follow the linked instructions to `verify the ISO <https://www.qubes-os.org/security/verifying-signatures/#how-to-verify-detached-pgp-signatures-on-qubes-isos>`_.
 
@@ -97,7 +97,7 @@ Once you've verified the ISO, copy it to your installation medium - for example,
 
 .. code-block:: sh
 
-  sudo dd if=Qubes-R4.1.1-x86_64.iso of=/dev/sdX bs=1048576 && sync
+  sudo dd if=Qubes-R4.1.2-x86_64.iso of=/dev/sdX bs=1048576 && sync
 
 where ``if`` is set to the path to your downloaded ISO file and ``of`` is set to
 the block device corresponding to your USB stick. Note that any data on the USB stick will be overwritten.


### PR DESCRIPTION
Updates the install docs to reference Qubes 4.1.2 (links to download page and ISO filename references) as Qubes 4.1.1 is no longer available for download.

## testing:
- [ ] CI is passing 
- [ ] `make  linkcheck` passes locally
- [ ] There are no references to Qubes 4.1.1 left
- [ ] The referenced ISO exist and (for extra credit) validation passes following the given instructions.