### PR TITLE
linkcheck fixes for our docs and new config.json.example location

### DIFF
--- a/docs/admin/backup.rst
+++ b/docs/admin/backup.rst
@@ -137,7 +137,7 @@ VM:
 
 Optionally, inspect each file before proceeding. The first
 file should be an ASCII-armored GPG private key file. The second file should
-follow the format of the `example configuration file <https://raw.githubusercontent.com/freedomofpress/securedrop-workstation/main/config.json.example>`_,
+follow the format of the `example configuration file <https://raw.githubusercontent.com/freedomofpress/securedrop-workstation/main/files/config.json.example>`_,
 with values for its fields (e.g., ``hostname``, ``submission_key_fpr``) specific to
 your configuration. The file may be formatted in a single line without whitespace.
 

--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -63,7 +63,7 @@ To verify when users were added to the system:
 - Click the **Admin** link in the top right.
 - Review the **Created** column in the list of users.
 
-To rotate passphrases for accounts, please see the `instructions <https://docs.securedrop.org/en/stable/admin.html#passphrases-and-two-factor-resets>`_ in the SecureDrop Admin Guide.
+To rotate passphrases for accounts, please see the `instructions <https://docs.securedrop.org/en/stable/admin/reference/admin_interface.html#passphrases-and-two-factor-resets>`_ in the SecureDrop Admin Guide.
 
 Apply BIOS updates and check settings
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Changes: 
- Update link to Securedrop passphrase reset instructions
- Update link to `config.json.example`

Testing:
- [ ] does CI pass?
- [ ] does `make docs-linkcheck` pass locally?
