### PR TITLE
document ThinkPad X1 Carbon compatibility

### DIFF
--- a/docs/admin/hardware.rst
+++ b/docs/admin/hardware.rst
@@ -19,6 +19,26 @@ More information on hardware compatibility can be found on the `Qubes OS System 
 
 In order to print submissions, a supported non-networked printer is required. We have tested and recommend the HP LaserJet Pro M404n. More printer options will be added in future releases.
 
+.. _thinkpad_x1_series:
+
+Lenovo X1 series laptops
+------------------------
+
+Lenovo ThinkPad X1 Carbon (10th-generation)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The 10th-generation Thinkpad X1 Carbon **with a 12th-generation Intel Core processor** is a recommended option for the SecureDrop Workstation beginning with Qubes 4.1.  If you plan to use it:
+
+- If your laptop has come with Ubuntu preinstalled, run its **Software Updater** twice as follows:
+
+  #. to install software updates, especially for the ``fwupd`` package; and then
+  #. to run ``fwupd`` to update the BIOS automatically.
+
+  If **Software Updater** offers to run ``fwupd`` during step (1), decline until step (2), to make sure ``fwupd`` itself has received its latest security updates.
+
+- Otherwise, follow the instructions below to ensure that the BIOS is up to date.
+
+You'll need to have a USB-to-Ethernet adapter on hand in order to :ref:`apply Qubes updates <apply_dom0_updates>`, which will enable Wi-Fi and fix glitchy video rendering and cursor performance.
+
 .. _thinkpad_t_series:
 
 Lenovo T series laptops

--- a/docs/admin/hardware.rst
+++ b/docs/admin/hardware.rst
@@ -115,8 +115,8 @@ The ThinkPad T480 is also a recommended option for SecureDrop Workstation, as it
 
 .. _thinkpad_bios:
 
-Upgrading the BIOS on ThinkPad models T480, T490, and T14
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Upgrading the BIOS on Lenovo ThinkPad laptops
+---------------------------------------------
 
 The instructions below assume the use of a Linux-based computer for the creation of a BIOS upgrade USB. To upgrade the BIOS:
 
@@ -126,7 +126,7 @@ The instructions below assume the use of a Linux-based computer for the creation
   #. On the **Main** tab, look for the **Machine Type Model**.  The first four characters, such as `20L5`, `20L6`, or `20S0`, are the machine type.
 
 - Visit `<https://support.lenovo.com>`_ in the Linux-based computer. Type the machine type found above into the search bar, then press **Enter**.
-- In the T480 Product Home page, select **Drivers And Software** and choose **BIOS/UEFI**.
+- In the "Product Home" page, select **Drivers And Software** and choose **BIOS/UEFI**.
 - Download the file called either **BIOS Update (Bootable CD)** or **BIOS Update (Utility & Bootable CD)**.
 
 .. note::
@@ -198,7 +198,7 @@ The instructions below assume the use of a Linux-based computer for the creation
 - Follow the on-screen instructions to update the BIOS, including any mandatory reboots. Note that the instructions may refer to an update CD instead of your update USB.
 
 USB-C ports
-~~~~~~~~~~~
+-----------
 If you intend to use USB-C ports, please note that our recommended BIOS settings will disable dual USB-C/Thunderbolt ports (recognizable by the Thunderbolt logo next to the port). The T480, for example, includes two USB-C ports, `specified <https://psref.lenovo.com/syspool/Sys/PDF/ThinkPad/ThinkPad_T480/ThinkPad_T480_Spec.PDF>`__ as follows:
 
 - 1 x USB 3.1 Gen 1 Type-C (Power Delivery, DisplayPort, Data transfer)

--- a/docs/admin/hardware.rst
+++ b/docs/admin/hardware.rst
@@ -26,7 +26,7 @@ Lenovo X1 series laptops
 
 Lenovo ThinkPad X1 Carbon (10th-generation)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The 10th-generation Thinkpad X1 Carbon **with a 12th-generation Intel Core processor** is a recommended option for the SecureDrop Workstation beginning with Qubes 4.1.  If you plan to use it:
+The 10th-generation ThinkPad X1 Carbon **with a 12th-generation Intel Core processor** is a recommended option for the SecureDrop Workstation beginning with Qubes 4.1.  If you plan to use it:
 
 - If your laptop has come with Ubuntu preinstalled, run its **Software Updater** twice as follows:
 
@@ -67,7 +67,7 @@ After Qubes starts for the first time, when ``sys-net`` fails to start, follow t
 
 Lenovo ThinkPad T490 (with 8th-generation Intel Core processor)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The Thinkpad T490 **with an 8th-generation Intel Core processor** is a recommended option for the SecureDrop Workstation. If you plan to use it, you should follow the instructions below to ensure that the BIOS is up to date and adequately configured before proceeding with the installation.
+The ThinkPad T490 **with an 8th-generation Intel Core processor** is a recommended option for the SecureDrop Workstation. If you plan to use it, you should follow the instructions below to ensure that the BIOS is up to date and adequately configured before proceeding with the installation.
 
 
 .. caution::

--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -156,6 +156,8 @@ Now, insert a safe USB device you intend to use with the SecureDrop Workstation.
 
 While we recommend against the use of a USB keyboard for security reasons, this error can also occur in combination with other USB devices on some hardware.
 
+.. _apply_dom0_updates:
+
 Apply ``dom0`` updates (estimated wait time: 15-30 minutes)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``dom0`` is the most trusted domain on Qubes OS, and has privileged access to all other VMs. As such, it is important to ensure that all available security updates have been applied to ``dom0`` as the first step after the installation.


### PR DESCRIPTION
Closes freedomofpress/securedrop-workstation#893.  Since this mini-HCL is becoming something of a garden of forking paths (insert this step for model X, prepend this step for model Y, ...), I've also taken the liberty of factoring out of some of the ~interventions~ sections that are no longer specific to the ThinkPad T series.