### PR TITLE
Update python:3.9-slim-bullseye image sha, and switch to nginx:mainline-alpine-slim

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,5 +1,5 @@
-# sha256 as of 2021-11-09
-FROM python:3.9-slim-bullseye@sha256:408de0cf1a057f5501ee6642ad24a4762738f63bacf09fb4c8d861669260b01e AS sphinx
+# sha256 as of 2023-10-16
+FROM python:3.9-slim-bullseye@sha256:b3415be51b8d2c8f35a6eb3db85e9ccdedf12beaa3b18ed4c2f769889717d02a AS sphinx
 
 ARG GIT_BRANCH=main
 RUN apt-get -q update && apt-get -qy upgrade && apt-get -qy install git make latexmk texlive-latex-extra
@@ -9,8 +9,8 @@ RUN poetry install
 # TODO: Once the latest stable tag uses poetry, we can drop the `poetry run` prefix
 RUN poetry run deploy/build $GIT_BRANCH
 
-# sha256 as of 2021-11-09
-FROM nginx:mainline-alpine@sha256:af466e4f12e3abe41fcfb59ca0573a3a5c640573b389d5287207a49d1324abd8
+# sha256 as of 2023-10-16
+FROM nginx:mainline-alpine-slim@sha256:1b0cb433e90260a96528c987ee78b797e842d510473935304a0931536d10f50d
 
 COPY deploy/nginx.conf /etc/nginx
 RUN mkdir -p /opt/nginx/run /opt/nginx/webroot/en/latest /opt/nginx/webroot/en/stable && chown -R nginx:nginx /opt/nginx


### PR DESCRIPTION
Equivalent of https://github.com/freedomofpress/securedrop-docs/pull/510 and https://github.com/freedomofpress/securedrop-dev-docs/pull/107

Works towards https://github.com/freedomofpress/infrastructure/issues/4407