### PR TITLE
Document the process of increasing sync timeouts

### DIFF
--- a/docs/admin/troubleshooting_connection.rst
+++ b/docs/admin/troubleshooting_connection.rst
@@ -203,6 +203,39 @@ at the same time. Start ``sd-proxy``, which will bring up ``sd-whonix``.
 
 If this does not resolve the issue, please contact us for assistance.
 
+Customizing Synchronization Timeouts
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The SecureDrop Workstation Client application performs a synchronization on
+launch, which may time out in situations where there are a large number of 
+sources on the server. To the extent possible, we recommend regularly removing
+sources that are no longer actively engaging with you, or any sources that
+appear to be spam.
+
+If you are able to login to the Client application, but sources are not
+appearing, you may be reaching a timeout for the synchronization process.
+To temporarily increase the timeout, and give the system more time to
+finish synchronizing with the server, you can perform the following steps:
+
+1. Log into the Qubes workstation
+2. Start a system Terminal in ``dom0`` by going to the Qubes Menu, then choose
+   *Terminal Emulator*
+3. Run the following commands::
+   
+       qvm-service --enable sd-app SDEXTENDEDTIMEOUT_600
+       qvm-shutdown sd-app && sleep 5 && qvm-start sd-app
+   
+4. Start the SecureDrop Client application, like normal
+
+These instructions will change the sync timeout to 10 minutes. If the sync
+fails to complete in that time, repeat the instructions, replacing the "600"
+with a larger value. We recommend increasing the number in increments
+of 100, and checking after each change to find the best value.
+
+Once the synchronization has completed and the sources have loaded, we advise
+going through and removing any unnecessary sources.
+
+
 Examining logs
 ~~~~~~~~~~~~~~
 You may wish to examine system logs on your own, or with our guidance. You can


### PR DESCRIPTION
When the client loads, it tries to synchronize with the server, which may time out if there are a substantial number of sources.

This commit adds a section to the connection troubleshooting guide to advise on how to increase the timeout value.

## Testing
- [ ] Visual review
- [ ] CI passes

Note: tested in browser with `make docs` and checked with `make docs-lint`