### PR TITLE
Qubes 4.2 download, menu and updater changes

### DIFF
--- a/docs/admin/install/install.rst
+++ b/docs/admin/install/install.rst
@@ -9,7 +9,7 @@ In order to decrypt submissions, your SecureDrop Workstation will need a copy of
 
 - First, use the network manager widget in the upper right panel to disable your network connection. These instructions refer to the ``vault`` VM, which has no network access by default, but if the SVS USB is attached to another VM by mistake, this will offer some protection against exfiltration.
 
-- Next, choose **Q > Domain: vault > vault: Files** to open the file manager in the ``vault`` VM.
+- Next, choose **Q > APPS > vault > Thunar File Manager** to open the file manager in the ``vault`` VM.
 
 - Connect the SVS USB to a USB port on the Qubes computer, then use the devices widget in the upper right panel to attach it to the ``vault`` VM. There will be three entries for the USB in the section titled **Data (Block) Devices**. Choose the *unlabeled* entry (*not* the one labeled "TAILS") annotated with a ``sys-usb`` text that ends with a number, like ``sys-usb:sdb2``. That is the persistent volume.
 
@@ -19,7 +19,7 @@ In order to decrypt submissions, your SecureDrop Workstation will need a copy of
 
   |Unlock TailsData|
 
-- Open a ``dom0`` terminal via **Q > Terminal Emulator**, and run the following command to list the SVS submission key details, including its fingerprint:
+- Open a ``dom0`` terminal via **Q > ⚙️ > Other > Xfce Terminal**, and run the following command to list the SVS submission key details, including its fingerprint:
 
   .. code-block:: sh
 
@@ -76,9 +76,9 @@ Users of SecureDrop Workstation must enter their username, passphrase and two-fa
 
 In order to set up KeePassXC for easy use:
 
-- Add KeePassXC to the application menu by selecting it from the list of available apps in **Q > Domain: vault > vault: Qube Settings > Applications** and pressing the button labeled **>** (do not press the button labeled **>>**, which will add *all* applications to the menu).
+- Add KeePassXC to the application menu by selecting it from the list of available apps in **Q > APPS > vault > Settings > Applications** and pressing the button labeled **>** (do not press the button labeled **>>**, which will add *all* applications to the menu).
 
-- Launch KeePassXC via **Q > Domain: vault > vault: KeePassXC**. When prompted to enable automatic updates, decline. ``vault`` is networkless, so the built-in update check will fail; the app will be updated through system updates instead.
+- Launch KeePassXC via **Q > APPS > vault > KeePassXC**. When prompted to enable automatic updates, decline. ``vault`` is networkless, so the built-in update check will fail; the app will be updated through system updates instead.
 
 - Close the application.
 
@@ -115,9 +115,9 @@ With the key and configuration available in ``dom0``, you're ready to set up Sec
 
 - First, re-enable the network connection using the network manager widget.
 
-- Next, start a terminal in the network-attached ``work`` VM, via **Q > Domain:work > work: Terminal**.
+- Next, start a terminal in the network-attached ``work`` VM, via **Q > APPS > work > Xfce Terminal**.
 
-.. note:: As the next steps include commands that must be typed exactly, you may want to open a browser in the ``work`` VM, open this documentation there, and copy-and-paste the commands below into your ``work`` terminal. Note that due to Qubes' default security settings you will *not* be able to paste commands into your ``dom0`` terminal. The ``work`` browser can be opened via **Q > Domain: work > work: Firefox**
+.. note:: As the next steps include commands that must be typed exactly, you may want to open a browser in the ``work`` VM, open this documentation there, and copy-and-paste the commands below into your ``work`` terminal. Note that due to Qubes' default security settings you will *not* be able to paste commands into your ``dom0`` terminal. The ``work`` browser can be opened via **Q > APPS > work > Firefox**
 
 - In the ``work`` terminal, run the following commands to download and add the SecureDrop signing key, which is needed to verify the SecureDrop Workstation package:
 

--- a/docs/admin/install/prepare.rst
+++ b/docs/admin/install/prepare.rst
@@ -38,7 +38,7 @@ If the Qubes hardware compatibility list entry for your computer recommends the 
 
 Download and verify Qubes OS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-On the working computer, download the Qubes OS ISO for version ``4.1.2`` from `https://www.qubes-os.org/downloads/ <https://www.qubes-os.org/downloads/#qubes-release-4-1-2>`_. The ISO is 5.4 GiB approximately, and may take some time to download based on the speed of your Internet connection.
+On the working computer, download the Qubes OS ISO for version ``4.2.1`` from `https://www.qubes-os.org/downloads/ <https://www.qubes-os.org/downloads/#qubes-release-4-2-1>`_. The ISO is 5.4 GiB approximately, and may take some time to download based on the speed of your Internet connection.
 
 Follow the linked instructions to `verify the ISO <https://www.qubes-os.org/security/verifying-signatures/#how-to-verify-detached-pgp-signatures-on-qubes-isos>`_.
 
@@ -46,7 +46,7 @@ Once you've verified the ISO, copy it to your installation medium - for example,
 
 .. code-block:: sh
 
-  sudo dd if=Qubes-R4.1.2-x86_64.iso of=/dev/sdX bs=1048576 && sync
+  sudo dd if=Qubes-R4.2.1-x86_64.iso of=/dev/sdX bs=1048576 && sync
 
 where ``if`` is set to the path to your downloaded ISO file and ``of`` is set to
 the block device corresponding to your USB stick. Note that any data on the USB stick will be overwritten.
@@ -89,7 +89,16 @@ Once the initial setup is complete, the login dialog will be displayed. Log in u
 
 If, during the installation, you encountered the grayed out option "USB qube configuration disabled", you must now create a VM to access your USB devices. If you did not encounter this issue, you can skip this section.
 
-To create a USB qube, open a ``dom0`` terminal via the Qubes menu (the **Q** icon in the upper left corner): **Q > Terminal Emulator**. Run the following command:
+To create a USB qube, open a ``dom0`` terminal via the Qubes menu (the **Q** icon in the upper left corner): **Q > ⚙️ > Other > Xfce Terminal**.
+
+.. tip::
+
+  For quicker access, you can add the ``dom0`` terminal to the "Favorites" section of the
+  Qubes menu (identified by a bookmark symbol). Right-click the entry and select
+  **Add to favorites**. To remove it at a later time, right-click the entry in your
+  list of favorites and select **Remove from favorites**.
+
+Run the following command:
 
 .. code-block:: sh
 
@@ -113,7 +122,7 @@ Apply ``dom0`` updates (estimated wait time: 15-30 minutes)
 
 After logging in, use the network manager widget in the upper-right panel to configure your network connection.
 
-Open a ``dom0`` terminal via the Qubes menu (the **Q** icon in the upper left corner): **Q > Terminal Emulator**. Run the following command:
+Open a ``dom0`` terminal via the Qubes menu (the **Q** icon in the upper left corner): **Q > ⚙️ > Other > Xfce Terminal**. Run the following command:
 
 .. code-block:: sh
 
@@ -131,7 +140,7 @@ After logging in again, confirm that the network manager successfully connects y
 
   .. note:: If Tor connections are blocked on your network, you may need to configure Tor to use bridges in order to get a connection. For more information, see the `Anon Connection Wizard <https://www.whonix.org/wiki/Anon_Connection_Wizard>`_ documentation.
 
-- Once Tor has connected, select **Q > Qubes Tools > Qubes Update** to update the system VMs. in the ``[Dom0] Qubes Updater`` window, first check ``Enable updates for qubes without known available updates``, then check all entries in the list above except for dom0 (which you have already updated in the previous step). Then, click **Next**. The system's VMs will be updated sequentially - this may take some time. When the updates are complete, click **Finish**.
+- Once Tor has connected, select **Q > ⚙️ > Qubes Tools > Qubes Update** to update the system VMs. in the ``[Dom0] Qubes OS Update`` window, check all entries in the list except ``dom0`` (which you have already updated in the previous step). Then, click **Update**. When the updates are complete, click **Next**.
 
 Install Fedora 40 template
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/admin/reference/backup.rst
+++ b/docs/admin/reference/backup.rst
@@ -21,7 +21,7 @@ Preserve files from ``dom0``
 Preserve key configuration files by coping them into the
 ``vault`` VM.
 
-In a ``dom0`` Terminal via **Q ▸ Terminal Emulator**:
+In a ``dom0`` Terminal via **Q > ⚙️ > Other > Xfce Terminal**:
 
   .. code-block:: sh
 
@@ -47,7 +47,7 @@ Back up SecureDrop Workstation
 Ensure your storage medium is plugged in, attached to ``sd-devices``,
 and unlocked.
 
-Navigate to **Q ▸ Qubes Tools ▸ Backup Qubes**, and move all VMs from
+Navigate to **Q ▸ ⚙️ > Qubes Tools ▸ Backup Qubes**, and move all VMs from
 "Selected" to "Available" by pressing the ``<<`` button.
 
 To target a VM for backup, highlight it and move it into the "Selected"
@@ -95,7 +95,7 @@ intend to restore from a backup.
 
 Example: If you restore only ``vault``, rename or delete the existing
 ``vault`` VM prior to restoring the backup. You can do so in
-**Q > Domain: vault > vault: Qube Settings** (the VM must not be running).
+**Q > APPS > vault > Settings** (the VM must not be running).
 
 Restore Backup
 ~~~~~~~~~~~~~~
@@ -103,7 +103,7 @@ Plug in your backup medium and unlock it as during the backup. By default
 on a new system, your peripheral devices will be managed by a VM called
 ``sys-usb``.
 
-Navigate to **Q ▸ Qubes Tools ▸ Restore Backup**, and enter the
+Navigate to **Q ▸ ⚙️ > Qubes Tools ▸ Restore Backup**, and enter the
 location of the backup file. You do not need to adjust the default Restore
 options, unless you have made customizations to the backup. Enter the
 decryption/verification passphrase, and proceed to restoring the available

--- a/docs/admin/reference/hardware.rst
+++ b/docs/admin/reference/hardware.rst
@@ -78,7 +78,7 @@ Network devices (Ethernet and Wi-Fi) will not immediately work out of the box an
 
 |screenshot_sys_net_pci_reset|
 
-Open a ``dom0`` terminal via **Q > Terminal Emulator**, and run the following command to list the devices connected to the ``sys-net`` VM.
+Open a ``dom0`` terminal via **Q > ⚙️ > Other > Xfce Terminal**, and run the following command to list the devices connected to the ``sys-net`` VM.
 
 .. code-block:: sh
 

--- a/docs/admin/reference/troubleshooting_connection.rst
+++ b/docs/admin/reference/troubleshooting_connection.rst
@@ -41,7 +41,7 @@ connection notification, it is most likely due to one of these causes.
 .. important::
 
    Not all VMs in Qubes OS have Internet access. For example, opening the Qubes
-   menu (top left) and clicking **Terminal Emulator** opens a ``dom0`` terminal
+   menu (top left) and clicking **Q > ⚙️ > Other > Xfce Terminal** opens a ``dom0`` terminal
    without Internet access. See our :ref:`networking architecture <Networking Architecture>`
    overview for additional background.
 
@@ -219,7 +219,7 @@ finish synchronizing with the server, you can perform the following steps:
 
 1. Log into the Qubes workstation
 2. Start a system Terminal in ``dom0`` by going to the Qubes Menu, then choose
-   *Terminal Emulator*
+   **Q > ⚙️ > Other > Xfce Terminal**
 3. Run the following commands::
    
        qvm-service --enable sd-app SDEXTENDEDTIMEOUT_600

--- a/docs/admin/reference/troubleshooting_updates.rst
+++ b/docs/admin/reference/troubleshooting_updates.rst
@@ -39,7 +39,7 @@ In order to examine the most recent log file:
 
 1. Open a terminal in ``dom0`` by clicking the Qubes menu
    icon in the upper left corner of your screen, and
-   selecting **Terminal Emulator**.
+   selecting **Q > ⚙️ > Other > Xfce Terminal**.
 
 2. Change to the ``~/.securedrop_launcher/logs/`` directory:
 
@@ -92,7 +92,7 @@ Note that ``dom0`` and ``apply_dom0`` are separate steps.
 ^^^^^^^^^^^^^^^^^^^^^^^^
 1. Open a terminal in ``dom0`` by clicking the Qubes menu
    icon in the upper left corner of your screen, and
-   selecting **Terminal Emulator**.
+   selecting **Q > ⚙️ > Other > Xfce Terminal**.
 
 2. Perform an interactive ``dom0`` update by running the
    following command:
@@ -131,7 +131,7 @@ and enable this updated key:
 
 1. Open a terminal in ``dom0`` by clicking the Qubes menu
    icon in the upper left corner of your screen, and
-   selecting **Terminal Emulator**.
+   selecting **Q > ⚙️ > Other > Xfce Terminal**.
    
 2. Run the following command:
 

--- a/docs/admin/reference/upgrading_fedora.rst
+++ b/docs/admin/reference/upgrading_fedora.rst
@@ -23,7 +23,7 @@ SecureDrop Workstation to use the Fedora 40 template.
 Install Fedora-40 template
 --------------------------
 
-In a ``dom0`` terminal (**Qubes Application Menu > Terminal Emulator**), type
+In a ``dom0`` terminal (**Q > ⚙️ > Other > Xfce Terminal**), type
 the following to download the Fedora 40 template:
 
 .. code:: sh
@@ -40,9 +40,8 @@ Type ``y`` to proceed with the installation.
 Update the Fedora-40 template
 -----------------------------
 Once the template installation is complete, update the template using the Qubes
-Updater. Click **Q > Qubes Tools > Qubes Update** in the application menu.
-Click the checkbox "Enable updates for qubes without known updates" option,
-and click the checkbox next to ``fedora-40-xfce``. Click **Next** and wait for
+Updater. Click **Q > ⚙️ > Qubes Tools > Qubes Update** in the application menu.
+Cick the checkbox next to ``fedora-40-xfce``. Click **Update** and wait for
 any available updates to be downloaded and applied.
 
 .. _configure_vms:
@@ -50,7 +49,7 @@ any available updates to be downloaded and applied.
 Configure VMs to use the new template
 -------------------------------------
 To apply the template to VMs that currently use an older version, open the
-Qube Manager via **Q > Qubes Tools > Qube Manager**. All VMs will be visible at
+Qube Manager via **Q > ⚙️ > Qubes Tools > Qube Manager**. All VMs will be visible at
 a glance; to change a VM's settings, right-click it and select **Qube Settings**.
 
 In the Qube Settings window, select ``fedora-40-xfce`` from the drop-down menu
@@ -83,7 +82,7 @@ restart only the VMs you have updated. If you get a ``sys-whonix`` prompt asking
 
 .. tip::
 
-   You can also use the **Qubes Template Manager** (also in **Q > Qubes Tools**)
+   You can also use the **Qubes Template Manager** (also in **Q > ⚙️ > Qubes Tools**)
    to make template changes. However, note that it will not allow you to make
    template changes for VMs that are currently running, so you may have to
    manually shut down VMs in the correct order to do so.

--- a/docs/journalist/submissions.rst
+++ b/docs/journalist/submissions.rst
@@ -62,7 +62,7 @@ Currently, a LUKS- or VeraCrypt-encrypted USB drive is required for exporting su
 2. If your drive is using VeraCrypt, you will need to unlock it manually:
 
    1. Open the file menu by clicking on the **Q** application menu (in the top left),
-      select **sd-devices** and click **Files**.
+      select **sd-devices** in the **APPS** section, and click **File Manager**.
    2. In the left sidebar, there should be an entry labeled **# GB Possibly Encrypted**,
       click it.
       |screenshot_veracrypt_sd_devices_files|


### PR DESCRIPTION
- Point to Qubes 4.2.1 ISO
- Update menu refrences consistent with the new Q menu
- Describe updater consistent with its new GUI

The new Q menu is fairly complex, and describing it in text alone is tricky. To recap:
- There's a vertical section with icons for search, domains, favorites, and system
- For domains, there's a horizontal sub-section "APPS |  TEMPLATES | SERVICE". 
- The menu always opens in the domains section
- The selection of "APPS", "TEMPLATES" or "SERVICE" is persistent when you open and close the menu

I've therefore adopted the following conventions:
- When the user needs to switch to the system section, indicate this with ⚙️
- When the user needs to operate on domains, always indicate whether they need to be in the APPS, TEMPLATES or SERVICE sub-section, because the menu may be on a different sub-section when they open it
- I'm not indicating explicitly when the user needs to be in the "Domains" section, since the menu always opens on that section


Refs #221