### PR TITLE
Move limitations document to general section

### DIFF
--- a/docs/general/known_issues.rst
+++ b/docs/general/known_issues.rst
@@ -1,7 +1,8 @@
 Limitations and known issues
 ============================
 
-.. include:: ../../includes/top-warning.rst
+.. include:: ../includes/top-warning.rst
+
 Reporting issues
 ----------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,7 @@ against malware and other security risks. It is built on Qubes OS and requires a
    general/introduction
    general/workstation_architecture
    general/status
+   general/known_issues
 
 .. toctree::
    :maxdepth: 2
@@ -52,7 +53,6 @@ against malware and other security risks. It is built on Qubes OS and requires a
    admin/reference/troubleshooting_connection
    admin/reference/troubleshooting_updates
    admin/reference/provisioning_usb
-   admin/reference/known_issues
    admin/reference/upgrading_fedora
    admin/reference/backup
 


### PR DESCRIPTION
Fixes #213 by moving the "Limitations and known issues" guide to the general section, rather than the Admin Guide.

## Testing

- [ ] Visual inspection
- [ ] CI passes