### PR TITLE
Improve troubleshooting instructions

### DIFF
--- a/docs/admin/install/troubleshoot.rst
+++ b/docs/admin/install/troubleshoot.rst
@@ -63,6 +63,38 @@ For both device IDs (e.g. ``dom0:00_1f.6`` and ``dom0:00_14.3``), you will need 
 
 .. |screenshot_sys_net_pci_reset| image:: ../../images/screenshot_sys_net_pci_reset.png
 
+Full system freezes
+~~~~~~~~~~~~~~~~~~~
+
+A `known issue <https://github.com/QubesOS/qubes-issues/issues/8825>`_ with some hardware results in Qubes fully freezing.
+If you encounter this issue, you will need to forcibly restart your computer, usually by holding down the power button.
+
+When you boot up, you will see a black-and-white menu with the following options:
+
+.. code-block:: text
+
+  Qubes, with Xen hypervisor
+  Advanced options for Qubes (with Xen hypervisor)
+  UEFI Firmware Settings
+
+While ``Qubes, with Xen hypervisor`` is selected, press :kbd:`e` to edit the option. You should now see a rudimentary
+edit interface.
+
+Find the line that starts with ``multiboot2   /xen-`` and ends with ``${xen_rm_opts}``. Use the arrow keys to move your
+cursor to before ``${xen_rm_opts}`` and type :kbd:`cpufreq=xen:hwp=off` (leave a space between ``off`` and the ``$``.
+
+Press :kbd:`Ctrl-x` to continue with booting. This will fix the current boot, we now need to make the fix permanent.
+
+Once Qubes has started and you have logged in, open a ``dom0`` terminal via **Q > Settings Gear > Other Tools > Xfce Terminal** and type
+:kbd:`sudo nano /etc/default/grub` to start an editor.
+
+Move your cursor to the bottom of the file and add: :kbd:`GRUB_CMDLINE_XEN_DEFAULT="$GRUB_CMDLINE_XEN_DEFAULT cpufreq=xen:hwp=off"`
+
+Press :kbd:`Ctrl-x`, then :kbd:`y`, and then :kbd:`Enter` to save the file.
+
+Finally, in the terminal run :kbd:`sudo grub2-mkconfig -o /boot/grub2/grub.cfg`. The workaround will now automatically be applied
+going forwards.
+
 .. |Attach TailsData| image:: images/attach_usb.png
   :width: 100%
 .. |Unlock Tailsdata| image:: images/unlock_tails_usb.png

--- a/docs/admin/install/troubleshoot.rst
+++ b/docs/admin/install/troubleshoot.rst
@@ -25,6 +25,44 @@ This is a transient error that may affect any of the SecureDrop Workstation VMs.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Transient network issues may cause an installation to fail. To work around this, verify that you have a working Internet connection, and re-run the ``sdw-admin --apply`` command.
 
+"Unable to reset PCI device"
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+On some hardware, network devices (Ethernet and Wi-Fi) will not immediately work out of the box and require a one-time manual configuration on install. After Qubes starts for the first time, ``sys-net`` will fail to start:
+
+|screenshot_sys_net_pci_reset|
+
+Open a ``dom0`` terminal via **Q > Settings Gear > Other Tools > Xfce Terminal**, and run the following command to list the devices connected to the ``sys-net`` VM.
+
+.. code-block:: sh
+
+  qvm-pci ls sys-net
+
+
+This will return the two devices (Ethernet and WiFi) that are connected to ``sys-net``:
+
+.. code-block:: sh
+
+  BACKEND:DEVID  DESCRIPTION                                                            USED BY
+  dom0:00_14.3   Network controller: Intel Corporation                                  sys-net
+  dom0:00_1f.6   Ethernet controller: Intel Corporation Ethernet Connection (5) I219-V  sys-net
+
+
+For both device IDs (e.g. ``dom0:00_1f.6`` and ``dom0:00_14.3``), you will need to detach and re-attach the device to ``sys-net``, then restart ``sys-net`` as follows:
+
+.. code-block:: sh
+
+  qvm-pci detach sys-net dom0:00_14.3
+  qvm-pci detach sys-net dom0:00_1f.6
+  qvm-pci attach sys-net --persistent --option no-strict-reset=True dom0:00_14.3
+  qvm-pci attach sys-net --persistent --option no-strict-reset=True dom0:00_1f.6
+  qvm-start sys-net
+
+
+``sys-net`` should now start, and network devices will be functional. This change is only required once on first install.  See the `Qubes documentation of this issue <https://www.qubes-os.org/doc/pci-troubleshooting/#unable-to-reset-pci-device-errors>`_ for more information.
+
+.. |screenshot_sys_net_pci_reset| image:: ../../images/screenshot_sys_net_pci_reset.png
+
 .. |Attach TailsData| image:: images/attach_usb.png
   :width: 100%
 .. |Unlock Tailsdata| image:: images/unlock_tails_usb.png

--- a/docs/admin/reference/hardware.rst
+++ b/docs/admin/reference/hardware.rst
@@ -74,41 +74,6 @@ The ThinkPad T490 **with an 8th-generation Intel Core processor** is a recommend
 
   The versions of the T490 with 10th generation Intel Core processors are at present **untested and unsupported**. The Workstation has been tested on models 20N2002AUS & 20N20046US.
 
-Network devices (Ethernet and Wi-Fi) will not immediately work out of the box and require a one-time manual configuration on install. After Qubes starts for the first time, ``sys-net`` will fail to start:
-
-|screenshot_sys_net_pci_reset|
-
-Open a ``dom0`` terminal via **Q > Terminal Emulator**, and run the following command to list the devices connected to the ``sys-net`` VM.
-
-.. code-block:: sh
-
-  qvm-pci ls sys-net
-
-
-This will return the two devices (Ethernet and WiFi) that are connected to ``sys-net``:
-
-.. code-block:: sh
-
-  BACKEND:DEVID  DESCRIPTION                                                            USED BY
-  dom0:00_14.3   Network controller: Intel Corporation                                  sys-net
-  dom0:00_1f.6   Ethernet controller: Intel Corporation Ethernet Connection (5) I219-V  sys-net
-
-
-For both device IDs (e.g. ``dom0:00_1f.6`` and ``dom0:00_14.3``), you will need to detach and re-attach the device to ``sys-net``, then restart ``sys-net`` as follows:
-
-.. code-block:: sh
-
-  qvm-pci detach sys-net dom0:00_14.3
-  qvm-pci detach sys-net dom0:00_1f.6
-  qvm-pci attach sys-net --persistent --option no-strict-reset=True dom0:00_14.3
-  qvm-pci attach sys-net --persistent --option no-strict-reset=True dom0:00_1f.6
-  qvm-start sys-net
-
-
-``sys-net`` should now start, and network devices will be functional. This change is only required once on first install.  See the `Qubes documentation of this issue <https://www.qubes-os.org/doc/pci-troubleshooting/#unable-to-reset-pci-device-errors>`_ for more information.
-
-.. |screenshot_sys_net_pci_reset| image:: ../../images/screenshot_sys_net_pci_reset.png
-
 Lenovo ThinkPad T480
 ~~~~~~~~~~~~~~~~~~~~
 The ThinkPad T480 is also a recommended option for SecureDrop Workstation, as it is being used by the core team for development and testing. If you plan to use it, you should follow the instructions below to ensure that the BIOS is up to date and adequately configured before proceeding with the installation:
@@ -205,4 +170,3 @@ If you intend to use USB-C ports, please note that our recommended BIOS settings
 - 1 x USB 3.1 Gen 2 Type-C / Intel Thunderbolt 3 (Power Delivery, DisplayPort, Data transfer)
 
 The first of these ports will continue to function as a USB-C port. After disabling Thunderbolt, the second port can no longer be used for Thunderbolt or for USB-C data transfer, but it can still be used for power delivery (i.e. to plug in your AC adapter). If you are unsure about the features of your laptop's USB-C ports, or if you are using a different make or model, please consult the technical specifications of your laptop for further information.
-


### PR DESCRIPTION
* Add `cpufreq=xen:hwp=off` full system freezes workaround
  * Document the workaround for
    <https://github.com/QubesOS/qubes-issues/issues/8825> by setting the
    corresponding Xen command-line parameter by editing the grub menu to be
    able to boot into a non-frozen state, and then the grub config itself to
    persist the workaround.
* Move "Unable to reset PCI device" to Troubleshooting page
  * Despite it only affecting specific hardware, this seems like a better
    place to document it when people run into it during installation.
    The only change to the text itself is that the dom0 terminal instructions
    now refer to the Qubes 4.2 way of opening it.

Fixes #226.