### PR TITLE
Remove uninstall instructions for documentation

### DIFF
--- a/docs/admin/install/troubleshoot.rst
+++ b/docs/admin/install/troubleshoot.rst
@@ -25,22 +25,6 @@ This is a transient error that may affect any of the SecureDrop Workstation VMs.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Transient network issues may cause an installation to fail. To work around this, verify that you have a working Internet connection, and re-run the ``sdw-admin --apply`` command.
 
-Uninstalling SecureDrop Workstation
------------------------------------
-To uninstall SecureDrop Workstation, open a ``dom0`` terminal and run the following command:
-
-.. code-block:: sh
-
-  sdw-admin --uninstall
-
-This will remove all associated VMs and configuration details, and uninstall the ``dom0`` SecureDrop Workstation package.
-
-The submission key and ``config.json`` file will still be present in ``dom0`` in ``/usr/share/securedrop-workstation-dom0-config``. To delete them, use the command:
-
-.. code-block:: sh
-
-   sudo shred /usr/share/securedrop-workstation-dom0-config/{config.json,sd-journalist.sec}
-
 .. |Attach TailsData| image:: images/attach_usb.png
   :width: 100%
 .. |Unlock Tailsdata| image:: images/unlock_tails_usb.png


### PR DESCRIPTION
Uninstalling isn't supported, just available as a developer tool.

Fixes #227.