### PR TITLE
Remove top warnings and bump version to 1.0.0

### DIFF
--- a/docs/admin/install/install.rst
+++ b/docs/admin/install/install.rst
@@ -1,6 +1,5 @@
 Installing SecureDrop Workstation
 =================================
-.. include:: ../../includes/top-warning.rst
 
 Copy the submission key
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/admin/install/overview.rst
+++ b/docs/admin/install/overview.rst
@@ -1,6 +1,5 @@
 SecureDrop Workstation Installation Overview
 ============================================
-.. include:: ../../includes/top-warning.rst
 
 Overview
 --------

--- a/docs/admin/install/prepare.rst
+++ b/docs/admin/install/prepare.rst
@@ -1,6 +1,5 @@
 Pre-install Tasks
 =================
-.. include:: ../../includes/top-warning.rst
 
 Apply BIOS updates and check settings
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/admin/install/troubleshoot.rst
+++ b/docs/admin/install/troubleshoot.rst
@@ -1,6 +1,5 @@
 Troubleshooting Installation Errors
 ===================================
-.. include:: ../../includes/top-warning.rst
 
 "Failed to return clean data"
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/admin/reference/backup.rst
+++ b/docs/admin/reference/backup.rst
@@ -1,8 +1,6 @@
 Backup and Restore
 ==================
 
-.. include:: ../../includes/top-warning.rst
-
 Qubes OS has a `backup utility <https://www.qubes-os.org/doc/backup-restore/>`_
 that allows for backup and restoration of user-specified VMs.
 

--- a/docs/admin/reference/hardware.rst
+++ b/docs/admin/reference/hardware.rst
@@ -1,8 +1,5 @@
-
 Recommended hardware
 ====================
-
-.. include:: ../../includes/top-warning.rst
 
 Qubes OS hardware requirements
 ------------------------------

--- a/docs/admin/reference/managing_clipboard.rst
+++ b/docs/admin/reference/managing_clipboard.rst
@@ -1,8 +1,6 @@
 Managing Clipboard Access
 =========================
 
-.. include:: ../../includes/top-warning.rst
-
 Every VM in Qubes has its own clipboard, similar to the clipboard of a Mac, Windows or Linux computer. For example, if you used the default ``work`` VM to browse the web and wanted to copy text from one browser window to another, you would use the ``Ctrl+C`` and ``Ctrl+V`` keyboard shortcuts to copy and paste. This type of clipboard usage -- copy and paste in the same VM -- also works in all VMs that are part of SecureDrop Workstation.
 
 In addition, Qubes supports copying information *between* VMs. This is done by using `special keyboard shortcuts <https://www.qubes-os.org/doc/copy-paste/>`_, ``Ctrl+Shift+C`` and ``Ctrl+Shift+V``, in a four-step process. By default, this is disabled for all VMs that are part of SecureDrop Workstation, consistent with the `principle of least privilege <https://en.wikipedia.org/wiki/Principle_of_least_privilege>`__.

--- a/docs/admin/reference/provisioning_usb.rst
+++ b/docs/admin/reference/provisioning_usb.rst
@@ -1,8 +1,6 @@
 Provisioning Export USB devices
 ===============================
 
-.. include:: ../../includes/top-warning.rst
-
 SecureDrop Workstation supports the export of submissions from the Qubes client
 to a LUKS- or VeraCrypt-encrypted USB *Export Device*.
 

--- a/docs/admin/reference/securing_workstation.rst
+++ b/docs/admin/reference/securing_workstation.rst
@@ -1,8 +1,6 @@
 Keeping the Workstation secure
 ==============================
 
-.. include:: ../../includes/top-warning.rst
-
 The *SecureDrop Workstation* provides the combined functionality of the 
 Tails-based *Journalist Workstation* and *Secure Viewing Station* (SVS). As such,
 it contains both a copy of the *Submission Private Key*, and encrypted and 

--- a/docs/admin/reference/troubleshooting_connection.rst
+++ b/docs/admin/reference/troubleshooting_connection.rst
@@ -1,8 +1,6 @@
 Troubleshooting connection problems
 ===================================
 
-.. include:: ../../includes/top-warning.rst
-
 Before troubleshooting connection problems, we recommend reading about the
 :ref:`networking architecture <Networking Architecture>`
 of SecureDrop Workstation. If you are in a hurry, this guide offers quick

--- a/docs/admin/reference/troubleshooting_updates.rst
+++ b/docs/admin/reference/troubleshooting_updates.rst
@@ -1,8 +1,6 @@
 Troubleshooting system updates
 ==============================
 
-.. include:: ../../includes/top-warning.rst
-
 After you log into Qubes, the SecureDrop Workstation
 preflight updater will prompt you to check for available
 system updates at least once per day.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,7 +60,7 @@ author = 'Freedom of the Press Foundation and Contributors'
 # built documents.
 #
 # The short X.Y version.
-version = '0.0.1'
+version = '1.0.0'
 # The full version, including alpha/beta/rc tags.
 # On the live site, this will be overridden to "stable" or "latest".
 release = os.environ.get("SECUREDROP_DOCS_RELEASE", version)

--- a/docs/general/introduction.rst
+++ b/docs/general/introduction.rst
@@ -20,7 +20,7 @@ not true of other operating systems.
 What is SecureDrop Workstation?
 -------------------------------
 
-SecureDrop Workstation is a pilot project that uses Qubes to make
+SecureDrop Workstation is a project that uses Qubes to make
 SecureDrop faster and simpler for journalists to use.
 
 A key feature of SecureDrop is that journalists can receive submissions from

--- a/docs/general/introduction.rst
+++ b/docs/general/introduction.rst
@@ -1,8 +1,6 @@
 Introduction
 ============
 
-.. include:: ../includes/top-warning.rst
-
 What is Qubes OS?
 -----------------
 

--- a/docs/general/known_issues.rst
+++ b/docs/general/known_issues.rst
@@ -1,8 +1,6 @@
 Limitations and known issues
 ============================
 
-.. include:: ../includes/top-warning.rst
-
 Reporting issues
 ----------------
 

--- a/docs/general/known_issues.rst
+++ b/docs/general/known_issues.rst
@@ -4,14 +4,18 @@ Limitations and known issues
 Reporting issues
 ----------------
 
-For the duration of the pilot, bugs and other issues found in
-*SecureDrop Workstation* should be reported by pilot participants via the
-`support portal <https://support.freedom.press>`_. Issues that are not instance-
-specific will be added to the appropriate public issue tracker by the developers,
-for example:
+Please report sensitive issues that are specific to your instance
+via the `support portal <https://support.freedom.press>`_. 
+
+Bugs and other issues that are not specific to your instance can be reported
+via GitHub using the following links:
 
  - `SecureDrop Workstation issues <https://github.com/freedomofpress/securedrop-workstation/issues>`_ - issues related to the Qubes environment and workstation provisioning.
  - `SecureDrop Client issues <https://github.com/freedomofpress/securedrop-client/issues>`_ - issues related to the *SecureDrop Client*.
+ 
+If you encounter a security-related issue, please see
+`SECURITY.md <https://github.com/freedomofpress/securedrop-workstation/blob/main/SECURITY.md>`_ 
+for instructions on how to privately report it.
 
 Current known issues
 --------------------

--- a/docs/general/status.rst
+++ b/docs/general/status.rst
@@ -1,18 +1,15 @@
 SecureDrop Workstation Project Status
 =====================================
 
-SecureDrop Workstation is currently in active development, and has not yet
-had a stable release.
+SecureDrop Workstation is currently in active development.
 
-The general availability release is tentatively planned for Q3/Q4 2024.
-
-Freedom of the Press Foundation has operated a pilot program with a limited
+Freedom of the Press Foundation had operated a pilot program with a limited
 number of organizations whose environments were especially well-suited for
-early testing of the Workstation. This pilot program is now closed. No new
-pilot participants will be considered or accepted, and current pilot
-participants can expect to transition to the standard support experience
-before the general availability release is made available later in 2024.
+early testing of the Workstation. This pilot program has now ended.
 
+With the 1.0.0 release, we’re now switching to an open beta. If you are
+interested in using SecureDrop Workstation, please reach out to us
+via the `support portal <https://support.freedom.press>`_.
 
 Is SecureDrop Workstation right for you?
 ----------------------------------------

--- a/docs/general/workstation_architecture.rst
+++ b/docs/general/workstation_architecture.rst
@@ -1,8 +1,6 @@
 SecureDrop Workstation Architecture
 ===================================
 
-.. include:: ../includes/top-warning.rst
-
 .. _Networking Architecture:
 
 SecureDrop Workstation networking architecture

--- a/docs/includes/getting_support.rst
+++ b/docs/includes/getting_support.rst
@@ -1,1 +1,1 @@
-If you are part of the SecureDrop Workstation Pilot and you have questions about this process or about any other aspect of SecureDrop Workstation, please reach out to us.
+If you have questions about this process or about any other aspect of SecureDrop Workstation, please reach out to us.

--- a/docs/includes/top-warning.rst
+++ b/docs/includes/top-warning.rst
@@ -1,4 +1,0 @@
-.. warning:: SecureDrop Workstation is currently in a closed beta, and we do not
-  recommend installing it for production purposes independently. See our
-  `blog post <https://securedrop.org/news/piloting-securedrop-workstation-qubes-os/>`__
-  for more information.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,8 +6,6 @@
 Welcome to the SecureDrop Workstation documentation!
 ====================================================
 
-.. include:: includes/top-warning.rst
-
 SecureDrop Workstation is a tool to enable journalists to communicate with
 anonymous sources and manage submitted documents, while providing mitigations
 against malware and other security risks. It is built on Qubes OS and requires a

--- a/docs/journalist/ending_session.rst
+++ b/docs/journalist/ending_session.rst
@@ -1,8 +1,6 @@
 Ending your session
 ===================
 
-.. include:: ../includes/top-warning.rst
-
 When you are finished using SecureDrop Workstation, close the SecureDrop Client window and shut the computer down completely. This is to take advantage of the protections of full-disk encryption, and to avoid unauthorized access to the Workstation and the files and materials on it, which include any messages and submissions that you have downloaded.
 
 To shut down the computer, click your username in the top righthand corner of

--- a/docs/journalist/faq.rst
+++ b/docs/journalist/faq.rst
@@ -108,7 +108,7 @@ our `design document <https://securedrop.org/whitepaper.pdf>`__.
 Can I install custom software on SecureDrop Workstation?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Right now, the pilot project is designed to make the journalist experience
+Right now, the project is designed to make the journalist experience
 easier by combining the functionality of the Journalist Workstation and Secure
 Viewing Station. The main focus is making sure that checking SecureDrop is
 easier and faster.

--- a/docs/journalist/sources.rst
+++ b/docs/journalist/sources.rst
@@ -1,8 +1,6 @@
 Communicating with sources
 ==========================
 
-.. include:: ../includes/top-warning.rst
-
 SecureDrop Workstation lets journalists check SecureDrop, decrypt and securely
 view submissions, and reply to sources, all on the same computer.
 

--- a/docs/journalist/starting_client.rst
+++ b/docs/journalist/starting_client.rst
@@ -1,8 +1,6 @@
 Starting the SecureDrop Client
 ==============================
 
-.. include:: ../includes/top-warning.rst
-
 After you log into Qubes, the SecureDrop Client app will start automatically. If
 you have previously exited the application, you can double-click on the
 **SecureDrop** desktop shortcut to launch it.

--- a/docs/journalist/starting_qubes.rst
+++ b/docs/journalist/starting_qubes.rst
@@ -1,8 +1,6 @@
 Starting Qubes
 ==============
 
-.. include:: ../includes/top-warning.rst
-
 When turning on SecureDrop Workstation, you will be greeted with a
 password prompt. This is the full-disk encryption passphrase.
 

--- a/docs/journalist/submissions.rst
+++ b/docs/journalist/submissions.rst
@@ -1,8 +1,6 @@
 Working with submissions
 ========================
 
-.. include:: ../includes/top-warning.rst
-
 When a source submits files, you will see a Download button in the conversation
 flow, a file size, and light-gray text that says "Encrypted file on server."
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "securedrop-workstation-docs"
-version = "0.0.1"
+version = "1.0.0"
 description = ""
 authors = ["SecureDrop team <securedrop@freedom.press>"]
 readme = "README.md"


### PR DESCRIPTION
This PR removes the top warnings (references to the SDW Pilot) and also bumps the version number to 1.0.0.

Closes #209 