### PR TITLE
Document `heic` and `avif` file support

### DIFF
--- a/docs/general/known_issues.rst
+++ b/docs/general/known_issues.rst
@@ -43,7 +43,7 @@ Current known issues
   Until this is fully supported, we suggest using the Tails-based *Secure Viewing
   Station* for pre-encrypted submissions.
 - There are a limited number of file types that can be viewed on
-  SecureDrop Workstation. Some file types (such as `.heic`) are not
+  SecureDrop Workstation. Some file types (such as `.eml`) are not
   yet supported for viewing, and must be exported via USB, and/or viewed using
   the Tails-based *Secure Viewing Station*. :doc:`Broader file type support is planned <supported_filetypes>`.
 - If the *Submission Key* for your SecureDrop server was rotated in the past,

--- a/docs/general/supported_filetypes.rst
+++ b/docs/general/supported_filetypes.rst
@@ -9,7 +9,7 @@ Currently-supported filetypes include:
 * Audio: .mp3, .mp4, .mpeg, .wav, .ogg (Ogg Vorbis)
 * Video: .mp4, .webm, .mov (Quicktime), .avi (Audio Video Interleave - Microsoft),
   .wmv (Windows Media Video)
-* Image: .gif, .png, .jpeg, .tiff, .svg, .ico, .webp
+* Image: .gif, .png, .jpeg, .tiff, .svg, .ico, .webp, .heic, .avif
 * Compressed archives: .zip, .tar.gz (although printer support for files inside
   an archive is still to be implemented)
 


### PR DESCRIPTION
And swap in `.eml` as our example of unsupported file type.