### PR TITLE
docs: warn about macOS 15 compatibility

### DIFF
--- a/docs/admin/reference/provisioning_usb.rst
+++ b/docs/admin/reference/provisioning_usb.rst
@@ -43,6 +43,15 @@ of its airgap:
 Creating a VeraCrypt-encrypted drive
 ------------------------------------
 
+.. Remove the following warning once securedrop-docs#599 and
+   veracrypt/VeraCrypt#1422 are resolved.
+
+.. warning::
+
+   If you plan to use your *Export Device* with computers running macOS 15
+   ("Sequoia") or later, you must also perform the VeraCrypt setup on that
+   version of macOS.
+
 - If it isn't already done, download and install the `VeraCrypt software <https://www.veracrypt.fr/en/Home.html>`_.
 - Start VeraCrypt from your computer's application or software interface.
 - Click **Create Volume**


### PR DESCRIPTION
## Status

Ready for review


## Description of Changes

Documents workaround for freedomofpress/securedrop-docs#599 after freedomofpress/securedrop-docs#628.


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [x] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
