### PR TITLE
Update Fedora version to 41 and Qubes iso version to 4.2.4. 

### DIFF
--- a/docs/admin/install/overview.rst
+++ b/docs/admin/install/overview.rst
@@ -15,7 +15,7 @@ Pre-install tasks:
 #. Install Qubes OS
 #. (Hardware-dependent) Apply USB fixes
 #. Apply updates to system templates
-#. Install and update Fedora 40 base template
+#. Install and update Fedora 41 base template
 
 Install tasks:
 ~~~~~~~~~~~~~~

--- a/docs/admin/install/prepare.rst
+++ b/docs/admin/install/prepare.rst
@@ -25,15 +25,15 @@ If the Qubes hardware compatibility list entry for your computer recommends the 
 
 Download and verify Qubes OS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-On the working computer, download the Qubes OS ISO and cryptographic hash values for version ``4.2.3`` from `https://www.qubes-os.org/downloads/ <https://www.qubes-os.org/downloads/#qubes-os-4-2-3>`_. The ISO is 6.9 GB approximately, and may take some time to download based on the speed of your Internet connection.
+On the working computer, download the Qubes OS ISO and cryptographic hash values for version ``4.2.4`` from `https://www.qubes-os.org/downloads/ <https://www.qubes-os.org/downloads/#qubes-os-4-2-4>`_. The ISO is 6.8 GB approximately, and may take some time to download based on the speed of your Internet connection.
 
 Follow the linked instructions to `verify the ISO <https://www.qubes-os.org/security/verifying-signatures/#how-to-verify-detached-pgp-signatures-on-qubes-isos>`_. Ensure that the ISO and hash values are in the same directory, then run:
 
 .. code-block:: sh
 
   gpg --keyserver-options no-self-sigs-only,no-import-clean --fetch-keys https://keys.qubes-os.org/keys/qubes-release-4.2-signing-key.asc
-  gpg -v --verify Qubes-R4.2.3-x86_64.iso.DIGESTS
-  sha256sum -c Qubes-R4.2.3-x86_64.iso.DIGESTS
+  gpg -v --verify Qubes-R4.2.4-x86_64.iso.DIGESTS
+  sha256sum -c Qubes-R4.2.4-x86_64.iso.DIGESTS
 
 The output should look like this:
 
@@ -47,7 +47,7 @@ The output should look like this:
 
   gpg: armor header: Hash: SHA256
   gpg: original file name=''
-  gpg: Signature made Mon Sep 16 09:46:51 2024 EDT
+  gpg: Signature made Mon 17 Feb 2025 12:00:00 AM EST
   gpg:                using RSA key 9C884DF3F81064A569A4A9FAE022E58F8E34D89F
   gpg: using pgp trust model
   gpg: Good signature from "Qubes OS Release 4.2 Signing Key" [unknown]
@@ -55,7 +55,7 @@ The output should look like this:
   gpg:          There is no indication that the signature belongs to the owner.
   Primary key fingerprint: 9C88 4DF3 F810 64A5 69A4  A9FA E022 E58F 8E34 D89F
   gpg: textmode signature, digest algorithm SHA256, key algorithm rsa4096
-  Qubes-R4.2.3-x86_64.iso: OK
+  Qubes-R4.2.4-x86_64.iso: OK
   sha256sum: WARNING: 20 lines are improperly formatted
 
 Specifically, you will want to make sure that you see "Good signature" listed in the text. If it does not report a good signature, try deleting the ISO and downloading it again.
@@ -64,7 +64,7 @@ Once you've verified the ISO, copy it to your installation medium - for example,
 
 .. code-block:: sh
 
-  sudo dd if=Qubes-R4.2.3-x86_64.iso of=/dev/sdX bs=1048576 && sync
+  sudo dd if=Qubes-R4.2.4-x86_64.iso of=/dev/sdX bs=1048576 && sync
 
 where ``if`` is set to the path to your downloaded ISO file and ``of`` is set to
 the block device corresponding to your USB stick. Note that any data on the USB stick will be overwritten.
@@ -98,7 +98,7 @@ After the disk is unlocked and Qubes starts, you will be prompted to complete th
 
 On the configuration screen, ensure that the following options are checked:
 
- - Default Template should be set to "Fedora 40 Xfce"
+ - Default Template should be set to "Fedora 41 Xfce"
  - "Create default system qubes (sys-net, sys-firewall, default DispVM)"
  - "Make sys-firewall and sys-usb disposable"
 

--- a/docs/admin/reference/troubleshooting_updates.rst
+++ b/docs/admin/reference/troubleshooting_updates.rst
@@ -62,11 +62,11 @@ line in the log file that looks similar to the following:
 
 .. code-block:: none
 
-  2023-03-30 20:12:11,821 - sd.sdw_updater_gui.UpdaterApp:71(upgrade_status)
+  2025-02-24 20:12:11,821 - sd.sdw_updater_gui.UpdaterApp:71(upgrade_status)
   INFO: Signal: upgrade_status {
   'dom0': <UpdateStatus.UPDATES_OK: '0'>,
   'apply_dom0': <UpdateStatus.UPDATES_OK: '0'>,
-  'fedora-40': <UpdateStatus.UPDATES_OK: '0'>,
+  'fedora-41-xfce': <UpdateStatus.UPDATES_OK: '0'>,
   'sd-large-bullseye-template': <UpdateStatus.UPDATES_OK: '0'>,
   'whonix-gateway-17': <UpdateStatus.UPDATES_FAILED: '3'>,
   'sd-small-bullseye-template': <UpdateStatus.UPDATES_OK: '0'>,
@@ -282,19 +282,17 @@ key and remove the expired one:
    unsure on how to resolve an error, please contact us
    for assistance.
 
-``fedora-40`` update failures
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-1. Click the Qubes menu and open a terminal in the ``fedora-40``
-   template.
+``fedora-41-xfce`` update failures
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+1. Launch the Qubes GUI Updater from the top righthand
+   tray icon. Ensure the ``fedora-41-xfce`` template is
+   selected.
 
-2. Perform an interactive template update by running the following
-   command:
+2. Run the updater, observing the output in the
+   updater dialog.
 
-   ``sudo dnf update``
-
-3. Follow the prompts to resolve any issues. If you are
-   unsure on how to resolve an error, please contact us
-   or assistance.
+3. If the update is not successful, contact Support
+   and provide the output you see in the dialog.
 
 ``apply_dom0`` update failures
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
- Update fedora version and Qubes version in docs
- Revise f41 template instructions to direct users to SDW updater. (Future: we can probably remove or combine some of the "update troubleshooting" issues to just suggest the Qubes GUI updater, but don't want to expand the scope of PR too much).

- Refs https://github.com/freedomofpress/securedrop-workstation/issues/1209

(Draft mode til release is out)