### PR TITLE
Recommend using exFAT for VeraCrypt drives

### DIFF
--- a/docs/admin/reference/provisioning_usb.rst
+++ b/docs/admin/reference/provisioning_usb.rst
@@ -74,7 +74,7 @@ Creating a VeraCrypt-encrypted drive
 - You will be asked if you need to store large files, select **No** and click **Next**.
 - Select the following options in the Volume Format dialog:
 
-  - Filesystem: FAT
+  - Filesystem: exFAT
   - Quick Format: unselected
 - Click **Next**. VeraCrypt will now collect entropy from your mouse movements.
   Randomly move your mouse cursor around the screen until the progress bar is filled up.


### PR DESCRIPTION
Now that we support it (c.f. https://github.com/freedomofpress/securedrop-workstation/issues/1267), recommend it to users since it supports larger files compared to FAT.