### PR TITLE
Add securedrop-docs PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+Fixes #
+
+## Test plan
+<!--Any instructions the reviewer should reproduce? Otherwise, delete this section. -->
+
+## Checklist
+
+This change accounts for:
+- [ ] local preview of changes beyond typo-level edits


### PR DESCRIPTION
See https://github.com/freedomofpress/securedrop-docs/pull/705. This repo didn't have one at all yet, just porting it over here as well. 