### PR TITLE
Reflect updater showing up on first reboot

### DIFF
--- a/docs/admin/install/install.rst
+++ b/docs/admin/install/install.rst
@@ -216,7 +216,7 @@ This command will take a considerable amount of time and approximately 4GB of ba
 Test the Workstation
 ~~~~~~~~~~~~~~~~~~~~
 
-The preflight updater will start automatically after logging into the system. Since the system should be up-to-date, no updates this step should be fast. Please follow the preflight updater's instructions. 
+The preflight updater will start automatically after logging into the system. Please follow the preflight updater's instructions. 
 
   .. note::
 


### PR DESCRIPTION
The preflight-updater always shows even on the first reboot  after installing the workstation. This changes the language to reflect this fact and moves the desktop icon to a note.

## Test plan
<!--Any instructions the reviewer should reproduce? Otherwise, delete this section. -->

## Checklist

This change accounts for:
- [ ] local preview of changes beyond typo-level edits