### PR TITLE
Update installation instructions for keyring and Qubes-Contrib

### DIFF
--- a/docs/admin/install/install.rst
+++ b/docs/admin/install/install.rst
@@ -16,14 +16,15 @@ First, you must configure the Qubes-Contrib repo, then download the SecureDrop W
 
     sudo qubes-dom0-update -y qubes-repo-contrib
     sudo rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-qubes-4-contrib-fedora
-    sudo qubes-dom0-update -y --clean securedrop-workstation-keyring
+    sudo qubes-dom0-update --clean -y securedrop-workstation-keyring
 
 - The SecureDrop Relase keyring will be installed on your machine. Wait 15 seconds for the key to be imported into the ``rpm`` database. Then:
 
   .. code-block:: sh
 
-    sudo qubes-dom0-update -y --clean securedrop-workstation-dom0-config
+    sudo qubes-dom0-update --clean -y securedrop-workstation-dom0-config
     sudo dnf -y remove qubes-repo-contrib
+    systemd-run --on-active=5min rpm -e gpg-pubkey-d0941e87-5d8c9210
 
 Configure SecureDrop Workstation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Refs https://github.com/freedomofpress/securedrop-workstation-keyring/issues/13
Leaving in draft mode until keyring package publication

## Test plan
- [x] Keyring is published on qubes-contrib (don't merge before!)
- [x] SDW release with keyring-compatible changes is released (don't merge before)
- [x] Visual review
- [x] Successful download of dom0 config rpm using steps described. (Test once package is in qubes-contrib).

## Checklist

This change accounts for:
- [x] local preview of changes beyond typo-level edits