### PR TITLE
Docs update for initial removal of sd-whonix references

### DIFF
--- a/docs/admin/reference/troubleshooting_connection.rst
+++ b/docs/admin/reference/troubleshooting_connection.rst
@@ -100,7 +100,6 @@ to sources, starring sources, deleting sources):
 - ``sd-gpg``
 - ``sd-log``
 - ``sd-proxy``
-- ``sd-whonix``
 - ``sys-firewall``
 - ``sys-net``
 - ``sys-whonix`` (during updates)
@@ -132,13 +131,12 @@ If all required VMs are running, proceed to the next step.
 Step 4: Verify that required VMs have connectivity
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 In step 1, you have already verified that you can connect to the
-Internet using ``sys-net``. Now, test whether ``sys-firewall``, ``sd-whonix``
-and ``sd-proxy`` are working.
+Internet using ``sys-net``. Now, test whether ``sys-firewall`` and ``sd-proxy`` are working.
 
 First, open a terminal in ``sys-firewall`` and run the ``ping google.com`` command.
 You should see similar output as in ``sys-net`` before.
 
-Now, open a terminal in ``sd-whonix`` and run the following command:
+Now, open a terminal in ``sd-proxy`` and run the following command:
 
 ``wget -qO- https://check.torproject.org/ | cat | grep -m 1 "Congratulations"``
 
@@ -148,35 +146,17 @@ Tor connection is working.
 You should see the text "Congratulations. This browser is configured to use Tor."
 or a similar message on the terminal.
 
-If the output does not include the text "Congratulations", keep the terminal
-window open and proceed to the next steps.
+If the output does not include the text "Congratulations", proceed to the next steps.
 
-If the command does include the expected text in ``sd-whonix``, also run it in
-``sd-proxy``. If it only fails in ``sd-proxy``, your workstation may be
-misconfigured, or the proxy may have crashed. In that case, skip ahead to step 6.
-We also recommend that you contact us, so we can help identify the root cause.
-
-Step 5: Restart Tor
-~~~~~~~~~~~~~~~~~~~
-If you have narrowed down the problem to ``sd-whonix``, try restarting Tor.
-You can do this from within the ``sd-whonix`` terminal using the following
-command:
-
-``sudo systemctl restart tor``
-
-If this does not resolve the issue, proceed to the next step.
-
-Step 6: Restart ``sd-proxy`` and ``sd-whonix``
+Step 5: Restart ``sd-proxy``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Restart ``sd-proxy`` and ``sd-whonix`` to attempt to restore connectivity:
+Restart ``sd-proxy`` to attempt to restore connectivity:
 
 1. Exit the SecureDrop app if it is running.
-2. Click the "Q" icon in the system tray (top right).
+2. Click the "Q" icon in the system tray (top left).
 3. Click **Run Qube Manager**
 4. Right-click ``sd-proxy`` in the list of VMs. Click **Shutdown qube**.
-5. Right-click ``sd-whonix`` in the list of VMs. Click **Shutdown qube**.
-6. Right-click ``sd-proxy`` in the list of VMs. Click **Start/Resume qube**.
-   The ``sd-whonix`` VM should start automatically.
+5. Right-click ``sd-proxy`` in the list of VMs. Click **Start/Resume qube**.
 
 If this does not resolve the issue, proceed to the next step.
 
@@ -188,16 +168,15 @@ Step 7: Restart ``sys-net`` and ``sys-firewall``
    You will temporarily lose all Internet connectivity in Qubes OS during this
    step.
 
-Using the same procedure as in the previous step, shut down ``sd-proxy``,
-``sd-whonix`` and ``sys-whonix`` (in this order). Attempt to shut down
+Using the same procedure as in the previous step, shut down ``sd-proxy``. Attempt to shut down
 ``sys-firewall``. You may see an error message telling you that other VMs still
 require access to ``sys-firewall``. Save your work in those VMs, shut them
 down, and attempt to shut down ``sys-firewall`` again.
 
 Finally, shut down ``sys-net``. The network manager icon should disappear.
 
-Now, start ``sys-whonix``, which will bring up ``sys-net`` and ``sys-firewall``
-at the same time. Start ``sd-proxy``, which will bring up ``sd-whonix``.
+Now, start ``sys-proxy``, which will bring up ``sys-net`` and ``sys-firewall``
+at the same time.
 
 If this does not resolve the issue, please contact us for assistance.
 

--- a/docs/admin/reference/troubleshooting_connection.rst
+++ b/docs/admin/reference/troubleshooting_connection.rst
@@ -128,7 +128,7 @@ please contact us for assistance.
 
 If all required VMs are running, proceed to the next step.
 
-Step 4: Verify that the network VMs have connectivity
+Step 4: Verify that required VMs have connectivity
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 In step 1, you have already verified that you can connect to the
 Internet using ``sys-net``. Now, test whether ``sys-firewall`` and ``sd-proxy`` are working.
@@ -136,9 +136,21 @@ Internet using ``sys-net``. Now, test whether ``sys-firewall`` and ``sd-proxy`` 
 First, open a terminal in ``sys-firewall`` and run the ``ping google.com`` command.
 You should see similar output as in ``sys-net`` before.
 
+Now, open a terminal in ``sd-proxy`` and run the following command:
+
+``curl -s --proxy socks5h://localhost:9150 https://check.torproject.org | grep Congratulations``
+
+This command contacts a service intended for web browsers to verify whether your
+Tor connection is working.
+
+You should see the text "Congratulations. This browser is configured to use Tor."
+or a similar message on the terminal.
+
+If the output does not include the text "Congratulations", proceed to the next steps.
+
 Step 5: Restart ``sd-proxy``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Restart ``sd-proxy`` to attempt to restore Tor connectivity:
+Restart ``sd-proxy`` to attempt to restore connectivity:
 
 1. Exit the SecureDrop app if it is running.
 2. Click the "Q" icon in the system tray (top left).

--- a/docs/admin/reference/troubleshooting_connection.rst
+++ b/docs/admin/reference/troubleshooting_connection.rst
@@ -128,7 +128,7 @@ please contact us for assistance.
 
 If all required VMs are running, proceed to the next step.
 
-Step 4: Verify that required VMs have connectivity
+Step 4: Verify that the network VMs have connectivity
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 In step 1, you have already verified that you can connect to the
 Internet using ``sys-net``. Now, test whether ``sys-firewall`` and ``sd-proxy`` are working.
@@ -136,21 +136,9 @@ Internet using ``sys-net``. Now, test whether ``sys-firewall`` and ``sd-proxy`` 
 First, open a terminal in ``sys-firewall`` and run the ``ping google.com`` command.
 You should see similar output as in ``sys-net`` before.
 
-Now, open a terminal in ``sd-proxy`` and run the following command:
-
-``wget -qO- https://check.torproject.org/ | cat | grep -m 1 "Congratulations"``
-
-This command contacts a service intended for web browsers to verify whether your
-Tor connection is working.
-
-You should see the text "Congratulations. This browser is configured to use Tor."
-or a similar message on the terminal.
-
-If the output does not include the text "Congratulations", proceed to the next steps.
-
 Step 5: Restart ``sd-proxy``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Restart ``sd-proxy`` to attempt to restore connectivity:
+Restart ``sd-proxy`` to attempt to restore Tor connectivity:
 
 1. Exit the SecureDrop app if it is running.
 2. Click the "Q" icon in the system tray (top left).

--- a/docs/admin/reference/troubleshooting_updates.rst
+++ b/docs/admin/reference/troubleshooting_updates.rst
@@ -67,8 +67,8 @@ line in the log file that looks similar to the following:
   'dom0': <UpdateStatus.UPDATES_OK: '0'>,
   'apply_dom0': <UpdateStatus.UPDATES_OK: '0'>,
   'fedora-42-xfce': <UpdateStatus.UPDATES_FAILED: '3'>,
-  'sd-large-bullseye-template': <UpdateStatus.UPDATES_OK: '0'>,
-  'sd-small-bullseye-template': <UpdateStatus.UPDATES_OK: '0'>,
+  'sd-large-bookworm-template': <UpdateStatus.UPDATES_OK: '0'>,
+  'sd-small-bookworm-template': <UpdateStatus.UPDATES_OK: '0'>,
   'recommended_action': <UpdateStatus.UPDATES_FAILED: '3'>}
 
 In this example, the ``fedora-42-xfce`` VM has failed to update.

--- a/docs/admin/reference/troubleshooting_updates.rst
+++ b/docs/admin/reference/troubleshooting_updates.rst
@@ -66,13 +66,12 @@ line in the log file that looks similar to the following:
   INFO: Signal: upgrade_status {
   'dom0': <UpdateStatus.UPDATES_OK: '0'>,
   'apply_dom0': <UpdateStatus.UPDATES_OK: '0'>,
-  'fedora-41-xfce': <UpdateStatus.UPDATES_OK: '0'>,
+  'fedora-42-xfce': <UpdateStatus.UPDATES_FAILED: '3'>,
   'sd-large-bullseye-template': <UpdateStatus.UPDATES_OK: '0'>,
-  'whonix-gateway-17': <UpdateStatus.UPDATES_FAILED: '3'>,
   'sd-small-bullseye-template': <UpdateStatus.UPDATES_OK: '0'>,
   'recommended_action': <UpdateStatus.UPDATES_FAILED: '3'>}
 
-In this example, the ``whonix-gateway-17`` VM has failed to update.
+In this example, the ``fedora-42-xfce`` VM has failed to update.
 This is indicated by the text ``<UpdateStatus.UPDATES_FAILED: '3'>``.
 
 It is possible that multiple steps have failed. Make note of any
@@ -282,10 +281,10 @@ key and remove the expired one:
    unsure on how to resolve an error, please contact us
    for assistance.
 
-``fedora-41-xfce`` update failures
+``fedora-42-xfce`` update failures
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 1. Launch the Qubes GUI Updater from the top righthand
-   tray icon. Ensure the ``fedora-41-xfce`` template is
+   tray icon. Ensure the ``fedora-42-xfce`` template is
    selected.
 
 2. Run the updater, observing the output in the

--- a/docs/general/introduction.rst
+++ b/docs/general/introduction.rst
@@ -57,10 +57,8 @@ FPF has directly sponsored Qubes OS development, and we encourage you to
 We use the `Python <https://www.python.org/>`_ programming language and many tools in its
 ecosystem, which you can support by `donating to the Python Software Foundation <https://www.python.org/psf/donations/>`_.
 
-SecureDrop Workstation VMs are powered by `Debian <https://www.debian.org/>`_,
-`Fedora <https://fedoraproject.org/>`_, and `Whonix <https://www.whonix.org/>`_, all
-of which rely on volunteer contributions and financial support. The
-`GNOME <https://www.gnome.org/>`_ project acts as an umbrella for many of the individual
+SecureDrop Workstation VMs are powered by `Debian <https://www.debian.org/>`_ and `Fedora <https://fedoraproject.org/>`_ both
+of which rely on volunteer contributions and financial support. The `GNOME <https://www.gnome.org/>`_ project acts as an umbrella for many of the individual
 software components we rely on.
 
 Finally, SecureDrop Workstation relies on many other open source projects such as

--- a/docs/general/workstation_architecture.rst
+++ b/docs/general/workstation_architecture.rst
@@ -47,7 +47,3 @@ running for the SecureDrop Client to successfully connect to the server.
    access the SecureDrop API via Tor, and should not be attached to VMs that are
    unrelated to SecureDrop.
 
-.. is this still relevant vv
-Qubes OS ships with a Whonix service called ``sys-whonix``. When troubleshooting
-connection issues specific to SecureDrop, ``sys-whonix`` is only relevant during
-updates of the Whonix VMs (e.g., while the preflight updater is running).

--- a/docs/general/workstation_architecture.rst
+++ b/docs/general/workstation_architecture.rst
@@ -35,18 +35,19 @@ Because the SecureDrop Client must connect to the SecureDrop
 *Application Server* in order to send or retrieve messages, documents, and
 replies, it can communicate through Qubes-internal Remote Procedure Calls (RPCs)
 with another VM, ``sd-proxy``, which can only access the open Internet through
-the Tor network, using the separate ``sd-whonix`` VM.
+the Tor network.
 
-Like all networked VMs, ``sd-whonix`` uses the ``sys-firewall`` service to
-connect to the network, which is provided via ``sys-net``. All four VMs must be
+Like all networked VMs, ``sd-proxy`` uses the ``sys-firewall`` service to
+connect to the network, which is provided via ``sys-net``. All three VMs must be
 running for the SecureDrop Client to successfully connect to the server.
 
 .. important::
 
-   The ``sd-whonix`` VM contains a sensitive authentication token required to
+   The ``sd-proxy`` VM contains a sensitive authentication token required to
    access the SecureDrop API via Tor, and should not be attached to VMs that are
    unrelated to SecureDrop.
 
+.. is this still relevant vv
 Qubes OS ships with a Whonix service called ``sys-whonix``. When troubleshooting
 connection issues specific to SecureDrop, ``sys-whonix`` is only relevant during
 updates of the Whonix VMs (e.g., while the preflight updater is running).


### PR DESCRIPTION
Fixes #341 
- Updates most references to whonix to reflect the change to Tor running directly in `sd-proxy` via  arti and without `sd-whonix`.
- There are still a few references to `whonix` as the default Qubes `whonix` templates are still present on the system, involved in updates, etc. 
- Also fixes a few stale references to fedora-41 and bullseye.
- By removing a stale troubleshooting step, this also fixes #309 

## Checklist

This change accounts for:
- [x] local preview of changes beyond typo-level edits