### PR TITLE
Remove keyring installation workarounds

### DIFF
--- a/docs/admin/install/install.rst
+++ b/docs/admin/install/install.rst
@@ -15,7 +15,6 @@ First, you must configure the Qubes-Contrib repo, then download the SecureDrop W
   .. code-block:: sh
 
     sudo qubes-dom0-update -y qubes-repo-contrib
-    sudo rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-qubes-4-contrib-fedora
     sudo qubes-dom0-update --clean -y securedrop-workstation-keyring
 
 - The SecureDrop Relase keyring will be installed on your machine. Wait 15 seconds for the key to be imported into the ``rpm`` database. Then:
@@ -24,7 +23,7 @@ First, you must configure the Qubes-Contrib repo, then download the SecureDrop W
 
     sudo qubes-dom0-update --clean -y securedrop-workstation-dom0-config
     sudo dnf -y remove qubes-repo-contrib
-    systemd-run --on-active=5min rpm -e gpg-pubkey-d0941e87-5d8c9210
+
 
 Configure SecureDrop Workstation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
**Do NOT publish** before the respective fixes (see links bellow) have trickled down to Qubes 4.2.

Removes temporary workarounds concerning the `qubes-repo-contrib` package. This workaround language was [were introduced](https://github.com/freedomofpress/securedrop-workstation-docs/pull/338) during the 1.5.0 release and can go away once the following patches have made it to stable Qubes 4.2:
- https://github.com/QubesOS/qubes-issues/issues/10310
- https://github.com/QubesOS/qubes-issues/issues/10311