### PR TITLE
Remove Whonix template mentions in updater docs

### DIFF
--- a/docs/admin/reference/troubleshooting_connection.rst
+++ b/docs/admin/reference/troubleshooting_connection.rst
@@ -102,7 +102,6 @@ to sources, starring sources, deleting sources):
 - ``sd-proxy``
 - ``sys-firewall``
 - ``sys-net``
-- ``sys-whonix`` (during updates)
 
 You can verify whether a VM is running or not by clicking the |blue_qube| icon in the
 system tray (top right). Only VMs that are currently running will appear in the

--- a/docs/admin/reference/troubleshooting_updates.rst
+++ b/docs/admin/reference/troubleshooting_updates.rst
@@ -258,13 +258,12 @@ key and remove the expired one:
       sub   rsa4096 2021-05-10 [E] [expires: 2027-05-24]
 
 
-``sd-*-template`` or ``whonix-gateway-17`` update failures
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+``sd-*-template`` update failures
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 1. Click the Qubes menu and open a terminal in the impacted
-   template. For example, if ``whonix-gateway-17`` failed to
+   template. For example, if ``sd-small-bookworm-template`` failed to
    update, select its entry in the Qubes menu and click
-   **Terminal**. (Be sure not to confuse it with the
-   similarly named ``whonix-workstation-17`` template.)
+   **Terminal**.
 
 2. Perform an interactive template update by running the
    the following commands:


### PR DESCRIPTION
No longer relevant since Whonix updates are no longer managed by updater since release 1.5.0.

## Checklist

This change accounts for:
- [ ] local preview of changes beyond typo-level edits
   - **NOTE:** I didn't manage to build this, but also didn't spend time trying to figure it out. Is this something the reviewer can do?