### PR TITLE
Remove references to support portal

### DIFF
--- a/docs/admin/reference/hardware.rst
+++ b/docs/admin/reference/hardware.rst
@@ -22,7 +22,7 @@ Qubes-certified laptops
 
 Qubes-certified laptops are certified and tested against Qubes major releases. They must support additional security features beyond the minimal requirements above, such as the use of `coreboot <https://www.coreboot.org/>`_ in place of proprietary firmware. Where possible, we recommend that you use a Qubes-certified laptop with ``coreboot`` for SecureDrop Workstation. A full list of certified computers can be found on the `Qubes OS Certified Hardware <https://www.qubes-os.org/doc/certified-hardware/>`_ page.
 
-        .. note:: Some certified computers also support the use of `Heads <https://osresearch.net>`_ with ``coreboot``, for additional protection against advanced attacks during the boot process. Heads adds a layer of complexity to the overall user experience, but may make sense for you as an option if you have an expectation of those kinds of threats. If you have questions about Heads, or other hardware choices, contact us via the `SecureDrop support portal <https://support.freedom.press>`_.
+        .. note:: Some certified computers also support the use of `Heads <https://osresearch.net>`_ with ``coreboot``, for additional protection against advanced attacks during the boot process. Heads adds a layer of complexity to the overall user experience, but may make sense for you as an option if you have an expectation of those kinds of threats. If you have questions about Heads, or other hardware choices, contact us via Signal`_.
 
 FPF-tested laptops
 ~~~~~~~~~~~~~~~~~~

--- a/docs/admin/reference/troubleshooting_updates.rst
+++ b/docs/admin/reference/troubleshooting_updates.rst
@@ -320,7 +320,7 @@ If this does not resolve the issue:
 3. The file can now be found in ``~/QubesIncoming/dom0/`` in the
    ``work`` VM.
 
-   Send us the file through a secure channel, such as our support portal.
+   Send us the file through a secure channel, such as via Signal.
    We will provide further instructions.
 
 Step 4: Restart the updater

--- a/docs/general/known_issues.rst
+++ b/docs/general/known_issues.rst
@@ -5,7 +5,7 @@ Reporting issues
 ----------------
 
 Please report sensitive issues that are specific to your instance
-via the `support portal <https://support.freedom.press>`_. 
+via Signal or another secure method. 
 
 Bugs and other issues that are not specific to your instance can be reported
 via GitHub using the following links:

--- a/docs/general/status.rst
+++ b/docs/general/status.rst
@@ -9,7 +9,7 @@ early testing of the Workstation. This pilot program has now ended.
 
 With the 1.0.0 release, we’re now switching to an open beta. If you are
 interested in using SecureDrop Workstation, please reach out to us
-via the `support portal <https://support.freedom.press>`_.
+via our `contact form <https://securedrop.org/help>`_.
 
 Is SecureDrop Workstation right for you?
 ----------------------------------------
@@ -76,6 +76,5 @@ Roadmap and Timeline
 You can find information about our current development roadmap and timeline at
 the `SecureDrop Development Wiki <https://github.com/freedomofpress/securedrop/wiki/Development-Roadmap>`_.
 
-We encourage former pilot participants and open beta participants to file support tickets
-with us, to help us understand and prioritize your needs as we continue development.
+We encourage former pilot participants and open beta participants to reach out, to help us understand and prioritize your needs as we continue development.
 

--- a/docs/journalist/faq.rst
+++ b/docs/journalist/faq.rst
@@ -116,11 +116,10 @@ easier and faster.
 While we hope to add advanced tooling and document-processing options down the line,
 at this time we request that you do not change the configuration of the workstation
 or install additional software on it. If you have specific needs that you would like
-to discuss with us, please open an issue `in our support portal`_ or send us a
-`GPG-encrypted email`_ at support@freedom.press.
+to discuss with us, please contact us via Signal, or send us a
+`PGP-encrypted email`_ at support@freedom.press.
 
-.. _`in our support portal`: https://support.freedom.press/
-.. _`GPG-encrypted email`: https://securedrop.org/sites/default/files/fpf-email.asc
+.. _`PGP-encrypted email`: https://securedrop.org/sites/default/files/fpf-email.asc
 
 Why can’t I save or print from the Viewer VM apps?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
As we are sunsetting the Redmine-based support portal in favor of Signal, this PR removes all references to it with only minimal changes. Previously the docs assumed readers were already in touch with us via the support portal and this PR maintains that assumption wrt Signal.

A future PR or more comprehensive rewrite should add a page and better information for getting support (see #357)