### PR TITLE
Update SDW docs for 2.13.0

### DIFF
--- a/docs/admin/install/troubleshoot.rst
+++ b/docs/admin/install/troubleshoot.rst
@@ -51,7 +51,7 @@ Failed to import *Journalist Interface* details
 
 If importing the *Journalist Interface* details using ``sdw-admin --configure`` fails, you can copy the configuration file to ``dom0`` manually.
 
-- If your *Journlist Interface* is based on SecureDrop 2.13.0 or later, use the following command:
+- If your *Journalist Interface* is based on SecureDrop 2.13.0 or later, use the following command:
 
   .. code-block:: sh
 


### PR DESCRIPTION
Fixes #359

Starting with version 2.13.0, SecureDrop is installed on Tails as a Debian package rather than as a cloned git repo. Configuration files are now stored in `~/.config/securedrop-admin`. 

The SecureDrop Workstation grabs some of these config files from SecureDrop Tails USB drives. This PR updates the documentation for manually extracting the Tor v3 client authentication key from a Journalist Workstation to reflect the new location where it is stored in Tails. I included the pre-2.13.0 instructions as well. 

I don't believe there are any other changes needed to this documentation, unless the function of the `sdw-admin --configure` command is changing. 