### PR TITLE
Remove GPG prompt instructions

### DIFF
--- a/docs/journalist/starting_client.rst
+++ b/docs/journalist/starting_client.rst
@@ -42,13 +42,6 @@ Interface.
 
 |screenshot_sd-app_login|
 
-After signing in, you will be prompted by a dialog that says “Do you allow VM
-‘sd-app’ to access your GPG keys (now and for the following 8 hours)?”.
-Click **Yes.** This dialogue may appear immediately after signing in, or when
-you click on a source submission.
-
-|screenshot_gpg_access|
-
 Troubleshooting tips
 ~~~~~~~~~~~~~~~~~~~~
 If you have trouble running the updater or logging in, please contact your


### PR DESCRIPTION
Prompt should no longer be present with with 1.6.0 workstation release. This was removed in https://github.com/freedomofpress/securedrop-workstation/pull/1466

Waiting: blocked on 1.6.0 workstation release.

Shall we also remove the screenshot?

## Test plan
<!--Any instructions the reviewer should reproduce? Otherwise, delete this section. -->

## Checklist

This change accounts for:
- [ ] local preview of changes beyond typo-level edits