### PR TITLE
Remove HTTP links and check for new ones as part of the linting process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ docs:  ## Build project documentation with live reload for editing.
 
 .PHONY: docs-lint
 docs-lint:  ## Check documentation for common syntax errors.
+	@echo "███ Checking for common errors..."
+	@./check_errors.sh
 	@echo "███ Linting documentation..."
 # The `-W` option converts warnings to errors.
 # The `-n` option enables "nit-picky" mode.

--- a/check_errors.sh
+++ b/check_errors.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+# Check for any HTTP links, except for those that are part of an onion address
+# or those that are part of the SVG XML spec
+if grep -R -I -n -P \
+   'http://(?![^[:space:]]*(\.onion|xml))' \
+   --exclude-dir='_build' \
+   --exclude='*.svg' \
+   --exclude='conf.py' \
+   docs/; then
+  echo "HTTP links found"
+  exit 1
+fi
+
+echo "No common errors found."
+exit 0

--- a/docs/_static/rtd_dark.css
+++ b/docs/_static/rtd_dark.css
@@ -1,6 +1,6 @@
 /*!
  * @name          Readthedocs
- * @namespace     http://userstyles.org
+ * @namespace     https://userstyles.org
  * @description	  Styles the documentation pages hosted on Readthedocs.io
  * @author        Anthony Post
  * @homepage      https://userstyles.org/styles/142968


### PR DESCRIPTION
This PR removes HTTP links where not required as either part of .onion names, or part of XML specs.

It also adds a check to the linter to make sure any new HTTP links are immediately flagged. 

## Test plan
- [x] Calling the linter now runs `check_errors.sh`
- [x] Try modifying the docs to add an http-only link.
- [x] Ensure that the linter throws an error
- [x] Change the link to HTTPS and ensure the linter is happy again
- [ ] Visual review
- [ ] CI passes