### PR TITLE
Document `sdw-upgrade` script

### DIFF
--- a/docs/admin/reference/upgrade_to_qubes_4.3.rst
+++ b/docs/admin/reference/upgrade_to_qubes_4.3.rst
@@ -99,8 +99,23 @@ Before you proceed with the upgrade to Qubes 4.3, it's recommended to perform
 some system cleanup that falls outside of the scope of what the SecureDrop 
 Workstation typically manages.
 
-If you're less familiar with Qubes, or if you have your own customizations and
-feel comfortable managing them independently, you may skip this step.
+To make this process as simple as possible, we provide a script which you can
+run from the ``dom0`` Terminal by running:
+
+.. code-block:: sh
+
+   sdw-upgrade
+   
+This script will remove old Fedora templates, remove Whonix (if installed), and
+perform a few other necessary cleanup tasks.
+   
+The script will warn you about the changes that will be made to your system, and will
+require you to confirm that you wish to continue by typing :kbd:`y` and pressing
+:kbd:`Enter` when prompted.
+
+If you encounter any error messages during this script and are unsure how to move forward,
+please be sure to `contact SecureDrop support via Signal <https://securedrop.org/help/>`_
+before proceeding.
 
 Remove deprecated VMs and templates
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/admin/reference/upgrade_to_qubes_4.3.rst
+++ b/docs/admin/reference/upgrade_to_qubes_4.3.rst
@@ -99,15 +99,15 @@ Before you proceed with the upgrade to Qubes 4.3, it's recommended to perform
 some system cleanup that falls outside of the scope of what the SecureDrop 
 Workstation typically manages.
 
-To make this process as simple as possible, we provide a script which you can
-run from the ``dom0`` Terminal by running:
+To make this process as simple as possible, we provide a script which
+will remove old Fedora templates, remove Whonix (if installed), and
+perform a few other necessary cleanup tasks.
+
+To use the script, open the ``dom0`` Terminal and then run:
 
 .. code-block:: sh
 
    sdw-upgrade
-   
-This script will remove old Fedora templates, remove Whonix (if installed), and
-perform a few other necessary cleanup tasks.
    
 The script will warn you about the changes that will be made to your system, and will
 require you to confirm that you wish to continue by typing :kbd:`y` and pressing


### PR DESCRIPTION
This PR adds (and slightly expands) the original documentation for the sdw-upgrade script that didn't make it in time for the 1.6.1 release

## Test plan
- [ ] Visual review

## Checklist

This change accounts for:
- [ ] local preview of changes beyond typo-level edits