### PR TITLE
Remove all existing references to the client

### DIFF
--- a/docs/admin/install/install.rst
+++ b/docs/admin/install/install.rst
@@ -150,9 +150,9 @@ The preflight updater will start automatically after logging into the system. Pl
 
   .. note::
 
-    If you close the SecureDrop Client during your session, you can launch it again using the SecureDrop icon on the desktop. 
+    If you close the SecureDrop Inbox during your session, you can launch it again using the SecureDrop icon on the desktop. 
 
-Once the update check is complete, the SecureDrop Client will launch. Log in using an existing journalist account and verify that sources are listed and submissions can be downloaded, decrypted, and viewed.
+Once the update check is complete, SecureDrop Inbox will launch. Log in using an existing journalist account and verify that sources are listed and submissions can be downloaded, decrypted, and viewed.
 
 .. _Password Management Section:
 

--- a/docs/general/known_issues.rst
+++ b/docs/general/known_issues.rst
@@ -35,7 +35,7 @@ Current known issues
   the Tails-based *Secure Viewing Station*. :doc:`Broader file type support is planned <supported_filetypes>`.
 - If the *Submission Key* for your SecureDrop server was rotated in the past,
   you must manually re-add the old key to your `sd-gpg` VM in order to
-  view old submissions in SecureDrop Client. `Contact Support <https://securedrop.org/help/>`_ for assistance.
+  view old submissions in SecureDrop Inbox. `Contact Support <https://securedrop.org/help/>`_ for assistance.
 - We do not support uninstalling SecureDrop Workstation without wiping all of
   Qubes OS. There is an ``--uninstall`` option for ``sdw-admin``, but it is not
   officially supported and will leave behind sensitive material in

--- a/docs/journalist/starting_client.rst
+++ b/docs/journalist/starting_client.rst
@@ -88,14 +88,6 @@ Any actions you take while in offline mode, such as sending replies or deleting 
 
 |screenshot_offline_mode_menu|
 
-Falling back to the legacy SecureDrop Client
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-If you encounter an issue with the new SecureDrop Inbox or would like to use the older SecureDrop Client, you can access it for a limited time via |qubes_menu| **▸** |qubes_menu_gear| 
-**▸ Other ▸ SecureDrop Client (legacy)**. The older SecureDrop Client will remain available until the end of May 2026.
-
-.. important:: Note that the older Client and newer Inbox sync and download data independently; any data you download in SecureDrop Inbox will have to be downloaded again in the Client, if you choose to use it, and vice versa.
-
 .. |screenshot_desktop-shortcut| image:: ../images/screenshot_desktop-shortcut.png
 .. |screenshot_update_prompt| image:: ../images/screenshot_update_prompt.png
 .. |screenshot_apply_updates| image:: ../images/screenshot_apply_updates.png


### PR DESCRIPTION
This PR removes all references to SecureDrop Client, as it has officially reached end of life.

Fixes #394

## Test plan
- [ ] Visual review

## Checklist

This change accounts for:
- [ ] local preview of changes beyond typo-level edits