### PR TITLE
Update template names in updates troubleshooting

### DIFF
--- a/docs/admin/reference/troubleshooting_updates.rst
+++ b/docs/admin/reference/troubleshooting_updates.rst
@@ -71,7 +71,7 @@ line in the log file that looks similar to the following:
   'sd-viewer-debian-13': <UpdateStatus.UPDATES_OK: '0'>,
   'recommended_action': <UpdateStatus.UPDATES_FAILED: '3'>}
 
-In this example, the ``fedora-42-xfce`` VM has failed to update.
+In this example, the ``fedora-43-xfce`` VM has failed to update.
 This is indicated by the text ``<UpdateStatus.UPDATES_FAILED: '3'>``.
 
 It is possible that multiple steps have failed. Make note of any
@@ -281,10 +281,10 @@ key and remove the expired one:
    unsure on how to resolve an error, please contact us
    for assistance.
 
-``fedora-42-xfce`` update failures
+``fedora-43-xfce`` update failures
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 1. Launch the Qubes GUI Updater from the top righthand
-   tray icon. Ensure the ``fedora-42-xfce`` template is
+   tray icon. Ensure the ``fedora-43-xfce`` template is
    selected.
 
 2. Run the updater, observing the output in the

--- a/docs/admin/reference/troubleshooting_updates.rst
+++ b/docs/admin/reference/troubleshooting_updates.rst
@@ -66,9 +66,9 @@ line in the log file that looks similar to the following:
   INFO: Signal: upgrade_status {
   'dom0': <UpdateStatus.UPDATES_OK: '0'>,
   'apply_dom0': <UpdateStatus.UPDATES_OK: '0'>,
-  'fedora-42-xfce': <UpdateStatus.UPDATES_FAILED: '3'>,
-  'sd-large-bookworm-template': <UpdateStatus.UPDATES_OK: '0'>,
-  'sd-small-bookworm-template': <UpdateStatus.UPDATES_OK: '0'>,
+  'fedora-43-xfce': <UpdateStatus.UPDATES_FAILED: '3'>,
+  'sd-inbox-debian-13': <UpdateStatus.UPDATES_OK: '0'>,
+  'sd-viewer-debian-13': <UpdateStatus.UPDATES_OK: '0'>,
   'recommended_action': <UpdateStatus.UPDATES_FAILED: '3'>}
 
 In this example, the ``fedora-42-xfce`` VM has failed to update.


### PR DESCRIPTION
Edits relating to the template names changes introduced in https://github.com/freedomofpress/securedrop-workstation/issues/1758 (technically fedora 43 was from a previous one, but I think it's fine to sneak that one in as well).

## Test plan
<!--Any instructions the reviewer should reproduce? Otherwise, delete this section. -->

## Checklist

This change accounts for:
- [ ] local preview of changes beyond typo-level edits