### PR TITLE
Add notify job to update k8s manifests on image rebuild

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,3 +27,25 @@ jobs:
       add-branch-tags: true
     secrets:
       registry-password: ${{ secrets.GITHUB_TOKEN }}
+
+  notify:
+    uses: freedomofpress/actionslib/.github/workflows/update-k8s-trigger.yaml@main
+    needs:
+    - build
+    if: ${{ needs.build.result == 'success' && github.ref_name == 'main' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        cluster:
+        - production
+        - staging
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: read
+    with:
+      trigger: sdo-workstation-docs/${{ matrix.cluster }}
+      sha: ${{ github.sha }}
+    secrets:
+      local-token: ${{ secrets.GITHUB_TOKEN }}
+      k8s-configs-token: ${{ secrets.K8S_CONFIGS_GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a job to trigger rebuild of the k8s manifests when the image is updated


## Checklist

This change accounts for:
- [x] local preview of changes beyond typo-level edits